### PR TITLE
Voodoo: separate prep and do commit tracking

### DIFF
--- a/src/lib/compile.mli
+++ b/src/lib/compile.mli
@@ -13,7 +13,7 @@ val folder : t -> Fpath.t
 val odoc : t -> Mld.Gen.odoc_dyn
 
 val v :
-  voodoo:Voodoo.t Current.t ->
+  voodoo:Voodoo.Do.t Current.t ->
   digests:Folder_digest.t Current.t ->
   blessed:Package.Blessed.t Current.t ->
   deps:t list Current.t ->

--- a/src/lib/misc.ml
+++ b/src/lib/misc.ml
@@ -13,7 +13,7 @@ let base_image_version package =
 
 let get_base_image package = Spec.make ("ocaml/opam:ubuntu-ocaml-" ^ base_image_version package)
 
-let network = Voodoo.network
+let network = [ "host" ]
 
 let docs_cache_folder = "/home/opam/docs-cache/"
 

--- a/src/lib/prep.mli
+++ b/src/lib/prep.mli
@@ -3,7 +3,7 @@ type t
 
 val package : t -> Package.t
 
-val v : voodoo:Voodoo.t Current.t -> digests:Folder_digest.t Current.t -> Jobs.t Current.t -> t list Current.t
+val v : voodoo:Voodoo.Prep.t Current.t -> digests:Folder_digest.t Current.t -> Jobs.t Current.t -> t list Current.t
 (** Install a package universe, extract useful files and push obtained universes. *)
 
 val folder : t -> Fpath.t

--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -6,40 +6,138 @@ let dune_cache = Obuilder_spec.Cache.v "opam-dune-cache" ~target:"/home/opam/.ca
 
 let cache = [ download_cache; dune_cache ]
 
-type mode = Prep | Do
-
-type t = Current_git.Commit.t
-
 module Git = Current_git
 
-let v =
+type t = { voodoo_do : Git.Commit_id.t; voodoo_prep : Git.Commit_id.t }
+
+module Op = struct
+  type voodoo = t
+
+  type t = No_context
+
+  let id = "voodoo-repository"
+
+  let pp f _ = Fmt.pf f "voodoo-repository"
+
+  let auto_cancel = false
+
+  module Key = struct
+    type t = Git.Commit.t
+
+    let digest = Git.Commit.hash
+  end
+
+  module Value = struct
+    type t = voodoo
+
+    let to_yojson commit =
+      let hash = Git.Commit_id.hash commit in
+      let repo = Git.Commit_id.repo commit in
+      let gref = Git.Commit_id.gref commit in
+      `Assoc [ ("hash", `String hash); ("repo", `String repo); ("gref", `String gref) ]
+
+    let of_yojson_exn json =
+      let open Yojson.Safe.Util in
+      let hash = json |> member "hash" |> to_string in
+      let gref = json |> member "gref" |> to_string in
+      let repo = json |> member "repo" |> to_string in
+      Git.Commit_id.v ~repo ~gref ~hash
+
+    let marshal { voodoo_do; voodoo_prep } =
+      `Assoc [ ("do", to_yojson voodoo_do); ("prep", to_yojson voodoo_prep) ]
+      |> Yojson.Safe.to_string
+
+    let unmarshal t =
+      let json = Yojson.Safe.from_string t in
+      let open Yojson.Safe.Util in
+      let voodoo_do = json |> member "do" |> of_yojson_exn in
+      let voodoo_prep = json |> member "prep" |> of_yojson_exn in
+      { voodoo_do; voodoo_prep }
+  end
+
+  let voodoo_prep_paths = Fpath.[ v "voodoo-prep.opam"; v "bin/prep/" ]
+
+  let voodoo_do_paths = Fpath.[ v "voodoo-do.opam"; v "voodoo-lib.opam"; v "bin/do/"; v "lib/" ]
+
+  let get_oldest_commit_for ~job ~dir ~from paths =
+    let paths = List.map Fpath.to_string paths in
+    let cmd = "git" :: "log" :: "-n" :: "1" :: "--format=format:%H" :: from :: "--" :: paths in
+    let cmd = ("", Array.of_list cmd) in
+    Current.Process.check_output ~cwd:dir ~job ~cancellable:false cmd |> Lwt_result.map String.trim
+
+  let with_hash ~id hash =
+    Git.Commit_id.v ~repo:(Git.Commit_id.repo id) ~gref:(Git.Commit_id.gref id) ~hash
+
+  let build No_context job commit =
+    let open Lwt.Syntax in
+    let ( let** ) = Lwt_result.bind in
+    let* () = Current.Job.start ~level:Harmless job in
+    Git.with_checkout ~job commit @@ fun dir ->
+    let id = Git.Commit.id commit in
+    let from = Git.Commit_id.hash id in
+    let** voodoo_prep = get_oldest_commit_for ~job ~dir ~from voodoo_prep_paths in
+    let** voodoo_do = get_oldest_commit_for ~job ~dir ~from voodoo_do_paths in
+    Current.Job.log job "Prep commit: %s" voodoo_prep;
+    Current.Job.log job "Do commit: %s" voodoo_do;
+    let voodoo_prep = with_hash ~id voodoo_prep in
+    let voodoo_do = with_hash ~id voodoo_do in
+    Lwt.return_ok { voodoo_prep; voodoo_do }
+end
+
+module VoodooCache = Current_cache.Make (Op)
+
+let v () =
   let daily = Current_cache.Schedule.v ~valid_for:(Duration.of_day 1) () in
-  Git.clone ~schedule:daily ~gref:"main" "git://github.com/ocaml-doc/voodoo"
+  let git = Git.clone ~schedule:daily ~gref:"main" "git://github.com/ocaml-doc/voodoo" in
+  let open Current.Syntax in
+  Current.component "voodoo"
+  |> let> git = git in
+     VoodooCache.get No_context git
 
 let remote_uri commit =
   let repo = Git.Commit_id.repo commit in
   let commit = Git.Commit_id.hash commit in
   repo ^ "#" ^ commit
 
-let spec ~base mode t =
-  let open Obuilder_spec in
-  base
-  |> Spec.add
-       ( match mode with
-       | Prep ->
-           [
-             run ~network "sudo apt-get update && sudo apt-get install -yy m4 pkg-config";
-             run ~network ~cache "opam pin -ny %s  && opam depext -iy voodoo-prep"
-               (t |> Git.Commit.id |> remote_uri);
-             run "cp $(opam config var bin)/voodoo-prep /home/opam";
-           ]
-       | Do ->
-           [
-             run ~network "sudo apt-get update && sudo apt-get install -yy m4";
-             run ~network
-               "opam pin -ny odoc %s && opam depext -iy odoc &&  opam exec -- odoc --version"
-               Config.odoc;
-             run ~network ~cache "opam pin -ny %s  && opam depext -iy voodoo-do"
-               (t |> Git.Commit.id |> remote_uri);
-             run "cp $(opam config var bin)/odoc $(opam config var bin)/voodoo-do /home/opam";
-           ] )
+module Prep = struct
+  type voodoo = t
+
+  type t = Git.Commit_id.t
+
+  let v { voodoo_prep; _ } = voodoo_prep
+
+  let spec ~base t =
+    let open Obuilder_spec in
+    base
+    |> Spec.add
+         [
+           run ~network "sudo apt-get update && sudo apt-get install -yy m4 pkg-config";
+           run ~network ~cache "opam pin -ny %s  && opam depext -iy voodoo-prep" (remote_uri t);
+           run "cp $(opam config var bin)/voodoo-prep /home/opam";
+         ]
+
+  let digest = Git.Commit_id.digest
+end
+
+module Do = struct
+  type voodoo = t
+
+  type t = Git.Commit_id.t
+
+  let v { voodoo_do; _ } = voodoo_do
+
+  let spec ~base t =
+    let open Obuilder_spec in
+    base
+    |> Spec.add
+         [
+           run ~network "sudo apt-get update && sudo apt-get install -yy m4";
+           run ~network
+             "opam pin -ny odoc %s && opam depext -iy odoc &&  opam exec -- odoc --version"
+             Config.odoc;
+           run ~network ~cache "opam pin -ny %s  && opam depext -iy voodoo-do" (remote_uri t);
+           run "cp $(opam config var bin)/odoc $(opam config var bin)/voodoo-do /home/opam";
+         ]
+
+  let digest = Git.Commit_id.digest
+end

--- a/src/lib/voodoo.mli
+++ b/src/lib/voodoo.mli
@@ -1,0 +1,29 @@
+type t
+
+val v : unit -> t Current.t
+
+val cache : Obuilder_spec.Cache.t list
+
+module Prep : sig
+  type voodoo = t
+
+  type t
+
+  val spec : base:Spec.t -> t -> Spec.t
+
+  val v : voodoo -> t
+
+  val digest : t -> string
+end
+
+module Do : sig
+  type voodoo = t
+
+  type t
+
+  val spec : base:Spec.t -> t -> Spec.t
+
+  val v : voodoo -> t
+
+  val digest : t -> string
+end

--- a/src/pipelines/docs.ml
+++ b/src/pipelines/docs.ml
@@ -75,7 +75,9 @@ let blacklist = [ "ocaml-secondary-compiler"; "ocamlfind-secondary" ]
 let v ~opam () =
   let open Current.Syntax in
   let digests = Folder_digest.v () in
-  let voodoo = Voodoo.v in
+  let voodoo = Voodoo.v () in
+  let v_do = Current.map Voodoo.Do.v voodoo in
+  let v_prep = Current.map Voodoo.Prep.v voodoo in
   let solver_result =
     let tracked =
       Track.v ~filter:[ "result"; "mirage"; "cohttp"; "irmin"; "base"; "parsexp" ] opam
@@ -98,7 +100,7 @@ let v ~opam () =
     @@ let+ res =
          Current.list_map
            (module Jobs)
-           (fun job -> Prep.v ~digests ~voodoo job |> Current.catch ~hidden:true)
+           (fun job -> Prep.v ~digests ~voodoo:v_prep job |> Current.catch ~hidden:true)
            jobs
        in
        List.filter_map Result.to_option res |> List.flatten
@@ -106,6 +108,6 @@ let v ~opam () =
   let blessed =
     Current.map (fun prep -> prep |> List.map Prep.package |> Package.Blessed.v) prepped
   in
-  compile ~digests ~voodoo ~blessed prepped
+  compile ~digests ~voodoo:v_do ~blessed prepped
   |> Current.map (List.filter_map Result.to_option)
   |> Indexes.v


### PR DESCRIPTION
Now that https://github.com/ocaml-doc/voodoo/pull/4 is merged, we can take advantage of it by tracking explicitly voodoo-prep and voodoo-do files. 