### PR TITLE
Static compilation graph

### DIFF
--- a/src/lib/compile.ml
+++ b/src/lib/compile.ml
@@ -65,7 +65,7 @@ let spec ~ssh ~remote_cache ~cache_key ~artifacts_digest ~base ~voodoo ~deps ~bl
            "rsync -avzR /home/opam/docs/./compile/ %s:%s/ && echo '%s'" (Config.Ssh.host ssh)
            (Config.Ssh.storage_folder ssh) artifacts_digest;
          (* Extract html output *)
-         run ~secrets:Config.Ssh.secrets ~network "rsync -e 'ssh -vv' -avzR /home/opam/docs/./html/ %s:%s/"
+         run ~secrets:Config.Ssh.secrets ~network "rsync -avzR /home/opam/docs/./html/ %s:%s/"
            (Config.Ssh.host ssh) (Config.Ssh.storage_folder ssh);
          (* Compute compile folder digest *)
          run "%s" (Remote_cache.cmd_compute_sha256 [ compile_folder ]);

--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -119,6 +119,8 @@ module Ssh = struct
   let port t = t.port
 
   let docs_public_endpoint t = t.html_endpoint
+
+  let digest t = Fmt.str "%s-%s-%d-%s" t.host t.user t.port t.folder |> Digest.string |> Digest.to_hex
 end
 
 type t = {

--- a/src/lib/config.mli
+++ b/src/lib/config.mli
@@ -20,6 +20,8 @@ module Ssh : sig
   val docs_public_endpoint : t -> string
   (** The public URL to access the docs files *)
   
+  val digest : t -> string
+  (** Updated when the storage location changes *)
 end
 
 type t

--- a/src/lib/misc.ml
+++ b/src/lib/misc.ml
@@ -36,7 +36,7 @@ let rsync_pull ~ssh ?(digest = "") folders =
   | [] -> Obuilder_spec.comment "no sources to pull"
   | _ ->
       Obuilder_spec.run ~secrets:Config.Ssh.secrets ~cache ~network
-        "rsync -e 'ssh -vv' --delete -avzR %s %s  && rsync -aR %s ./ && echo 'pulled: %s'" sources
+        "rsync --delete -avzR %s %s  && rsync -aR %s ./ && echo 'pulled: %s'" sources
         docs_cache_folder cache_sources digest
 
 

--- a/src/lib/prep.ml
+++ b/src/lib/prep.ml
@@ -104,7 +104,7 @@ let spec ~ssh ~remote_cache ~cache_key ~artifacts_digest ~voodoo ~base ~(install
          (* Perform the prep step for all packages *)
          run "opam exec -- ~/voodoo-prep -u %s" (universes_assoc prep);
          (* Upload artifacts *)
-         run ~secrets:Config.Ssh.secrets ~network "rsync -avz -e 'ssh -vv' prep %s:%s/ && echo '%s'"
+         run ~secrets:Config.Ssh.secrets ~network "rsync -avz prep %s:%s/ && echo '%s'"
            (Config.Ssh.host ssh) (Config.Ssh.storage_folder ssh) artifacts_digest;
          (* Compute artifacts digests, write cache key and upload them *)
          run "%s" (Remote_cache.cmd_write_key cache_key (prep |> List.rev_map folder));

--- a/src/lib/prep.ml
+++ b/src/lib/prep.ml
@@ -96,8 +96,7 @@ let spec ~ssh ~remote_cache ~cache_key ~artifacts_digest ~voodoo ~base ~(install
          env "DUNE_CACHE_DUPLICATION" "copy";
          (* Intall packages: this might fail.
             TODO: we could still do the prep step for the installed packages. *)
-         run ~network ~cache "sudo apt update && opam depext -viy %s"
-           packages_str;
+         run ~network ~cache "sudo apt update && opam depext -viy %s" packages_str;
          run ~cache "du -sh /home/opam/.cache/dune";
          (* empty preps should yield an empty folder *)
          run "mkdir -p %s" (base_folders prep);
@@ -110,8 +109,7 @@ let spec ~ssh ~remote_cache ~cache_key ~artifacts_digest ~voodoo ~base ~(install
          (* Compute artifacts digests, write cache key and upload them *)
          run "%s" (Remote_cache.cmd_write_key cache_key (prep |> List.rev_map folder));
          run "%s" (Remote_cache.cmd_compute_sha256 (prep |> List.rev_map folder));
-         run ~secrets:Config.Ssh.secrets ~network "%s"
-           (Remote_cache.cmd_sync_folder remote_cache);
+         run ~secrets:Config.Ssh.secrets ~network "%s" (Remote_cache.cmd_sync_folder remote_cache);
        ]
 
 module Prep = struct
@@ -288,18 +286,18 @@ let combine ~(job : Jobs.t) artifacts_digests =
            (package_digest, artifacts_digest))
     |> StringMap.of_seq
   in
-  List.map
-    (fun package ->
-      let digest = StringMap.find (Package.digest package) artifacts_digests in
-      { package; artifacts_digest = digest })
-    packages
+  packages |> List.to_seq
+  |> Seq.map (fun package ->
+         ( package,
+           let digest = StringMap.find (Package.digest package) artifacts_digests in
+           { package; artifacts_digest = digest } ))
+  |> Package.Map.of_seq
 
 (** Assumption: packages are co-installable *)
-let v ~config ~voodoo ~(cache : Remote_cache.t Current.t) (job : Jobs.t Current.t) =
+let v ~config ~voodoo ~(cache : Remote_cache.t Current.t) (job : Jobs.t) =
   let open Current.Syntax in
-  let* jobv = job in
-  Current.component "voodoo-prep %s" (jobv.install |> Package.digest)
-  |> let> voodoo = voodoo and> job = job and> cache = cache in
+  Current.component "voodoo-prep %s" (job.install |> Package.digest)
+  |> let> voodoo = voodoo and> cache = cache in
      let artifacts_cache =
        List.map (fun package -> Remote_cache.get cache (folder package)) job.prep
      in

--- a/src/lib/prep.mli
+++ b/src/lib/prep.mli
@@ -3,7 +3,7 @@ type t
 
 val package : t -> Package.t
 
-val v : config:Config.t -> voodoo:Voodoo.Prep.t Current.t -> cache:Remote_cache.t Current.t -> Jobs.t Current.t -> t list Current.t
+val v : config:Config.t -> voodoo:Voodoo.Prep.t Current.t -> cache:Remote_cache.t Current.t -> Jobs.t -> t Package.Map.t Current.t
 (** Install a package universe, extract useful files and push obtained universes. *)
 
 val folder : t -> Fpath.t

--- a/src/lib/remote_cache.ml
+++ b/src/lib/remote_cache.ml
@@ -80,18 +80,23 @@ let cmd_sync_folder t =
   Fmt.str "rsync -e 'ssh -vv' -avz cache %s:%s/" (Config.Ssh.host t) (Config.Ssh.storage_folder t)
 
 module Op = struct
-  type t = Config.Ssh.t
+  type t = No_context
 
   let pp f _ = Fmt.pf f "remote cache"
 
-  module Key = Current.Unit
+  module Key = struct
+    type t = Config.Ssh.t
+
+    let digest = Config.Ssh.digest
+  end
+
   module Value = Current.Unit
 
   let auto_cancel = true
 
   let id = id
 
-  let build ssh job () =
+  let build No_context job ssh =
     let open Lwt.Syntax in
     let* () = Current.Job.start ~level:Mostly_harmless job in
     let* () = sync ~job ssh in
@@ -105,6 +110,6 @@ let v ssh =
   let+ _ = 
     Current.primitive
       ~info:(Current.component "remote cache pull")
-      (Cache.get ssh) (Current.return ())
+      (Cache.get No_context) (Current.return ssh)
   in
   ssh

--- a/src/lib/remote_cache.ml
+++ b/src/lib/remote_cache.ml
@@ -77,7 +77,7 @@ let cmd_compute_sha256 paths =
   Fmt.(str "%a" (list ~sep:(any " && ") pp_compute_digest) paths)
 
 let cmd_sync_folder t =
-  Fmt.str "rsync -e 'ssh -vv' -avz cache %s:%s/" (Config.Ssh.host t) (Config.Ssh.storage_folder t)
+  Fmt.str "rsync -avz cache %s:%s/" (Config.Ssh.host t) (Config.Ssh.storage_folder t)
 
 module Op = struct
   type t = No_context


### PR DESCRIPTION
Web UI: group nodes so that we never display the full graph, as it would likely crash the server.

SSH: revert the use of `-vv`