### PR TITLE
Status json

### DIFF
--- a/src/lib/indexes.ml
+++ b/src/lib/indexes.ml
@@ -41,9 +41,16 @@ module Index = struct
 
   let mkdir_p d =
     let segs = Fpath.segs (Fpath.normalize d) |> List.filter (fun s -> String.length s > 0) in
+    let init, segs =
+      match segs with
+      | "" :: xs -> Fpath.v "/", xs
+      | _ -> Fpath.v ".", segs
+    in
     let _ = List.fold_left (fun path seg ->
     let d = Fpath.(path // v seg) in
-      try Unix.mkdir (Fpath.to_string d) 0o755; d with
+      try
+        Log.app (fun f -> f "mkdir %a" Fpath.pp d);
+        Unix.mkdir (Fpath.to_string d) 0o755; d with
       | Unix.Unix_error (Unix.EEXIST, _, _) -> d
       | exn -> raise exn) (Fpath.v ".") segs in
     ()

--- a/src/lib/indexes.ml
+++ b/src/lib/indexes.ml
@@ -1,0 +1,91 @@
+let id = "indexes"
+
+let state_dir = Current.state_dir id
+
+module Index = struct
+
+  type t = Config.Ssh.t
+
+  let id = "update-status-metadata"
+
+  let auto_cancel = true
+
+  module Key = struct
+    type t = string
+    
+
+  let digest package_name =
+    Format.asprintf "status-%s" package_name 
+
+  end
+
+  module Value = struct
+   type t = (string * Web.Status.t) list
+
+   let digest v =
+    Format.asprintf "%a" (Fmt.list (Fmt.pair Format.pp_print_string Web.Status.pp)) v
+  end
+
+  let pp f (package_name, _) = Fmt.pf f "Status update package %s" package_name
+
+  module Outcome = Current.Unit
+
+  type versions = { 
+    version : string;
+    link : string;
+    status : string;
+  } [@@deriving yojson]
+
+  type v_list = versions list [@@deriving yojson]
+
+
+  let mkdir_p d =
+    let segs = Fpath.segs (Fpath.normalize d) |> List.filter (fun s -> String.length s > 0) in
+    let _ = List.fold_left (fun path seg ->
+    let d = Fpath.(path // v seg) in
+      try Unix.mkdir (Fpath.to_string d) 0o755; d with
+      | Unix.Unix_error (Unix.EEXIST, _, _) -> d
+      | exn -> raise exn) (Fpath.v ".") segs in
+    ()
+  
+  let publish ssh job package_name v =
+    let open Lwt.Syntax in
+    let dir = Fpath.(state_dir / package_name) in
+    mkdir_p dir;
+    let file = Fpath.(dir / "state.json") in
+    let ts = List.map (fun (version, status) -> 
+      { version;
+        link = Format.asprintf "/tailwind/packages/%s/%s/index.html" package_name version; 
+        status = Fmt.to_to_string Web.Status.pp status}) v in
+    let j = v_list_to_yojson ts in
+    let f = open_out (Fpath.to_string file) in
+    output_string f (Yojson.Safe.to_string j);
+    close_out f;
+    let remote_folder =
+      Fmt.str "%s@@%s:%s/" (Config.Ssh.user ssh) (Config.Ssh.host ssh) (Config.Ssh.storage_folder ssh)
+    in
+    let switch = Current.Switch.create ~label:"ssh" () in
+  let* () = Current.Job.use_pool ~switch job Remote_cache.ssh_pool in
+  let* _ =
+    Current.Process.exec ~cancellable:true ~job
+      ( "",
+        [|
+          "rsync";
+          "-avzR";
+          "-e";
+          Fmt.str "ssh -o StrictHostKeyChecking=no -p %d -i %a" (Config.Ssh.port ssh) Fpath.pp (Config.Ssh.priv_key_file ssh);
+          remote_folder ^ "/html/tailwind/packages/./";
+          Fpath.to_string state_dir;
+        |] )
+  in
+  let* () = Current.Switch.turn_off switch in
+  Lwt.return (Ok ())
+end
+
+module StatCache = Current_cache.Output (Index)
+
+let v ~ssh ~package_name ~statuses : unit Current.t =
+  let open Current.Syntax in
+  Current.component "set-status" |>
+  let> statuses = statuses in
+  StatCache.set ssh package_name statuses

--- a/src/lib/indexes.ml
+++ b/src/lib/indexes.ml
@@ -52,7 +52,7 @@ module Index = struct
         Log.app (fun f -> f "mkdir %a" Fpath.pp d);
         Unix.mkdir (Fpath.to_string d) 0o755; d with
       | Unix.Unix_error (Unix.EEXIST, _, _) -> d
-      | exn -> raise exn) (Fpath.v ".") segs in
+      | exn -> raise exn) init segs in
     ()
   
   let publish ssh job package_name v =

--- a/src/lib/indexes.ml
+++ b/src/lib/indexes.ml
@@ -15,7 +15,7 @@ module Index = struct
     
 
   let digest package_name =
-    Format.asprintf "status-%s" package_name 
+    Format.asprintf "status2-%s" package_name 
 
   end
 
@@ -73,16 +73,17 @@ module Index = struct
     in
     let switch = Current.Switch.create ~label:"ssh" () in
   let* () = Current.Job.use_pool ~switch job Remote_cache.ssh_pool in
+  let* () = Current.Job.start ~level:Mostly_harmless job in
   let* _ =
     Current.Process.exec ~cancellable:true ~job
-      ( "",
+      ( Fpath.to_string state_dir,
         [|
           "rsync";
           "-avzR";
           "-e";
           Fmt.str "ssh -o StrictHostKeyChecking=no -p %d -i %a" (Config.Ssh.port ssh) Fpath.pp (Config.Ssh.priv_key_file ssh);
-          Fpath.to_string state_dir;
-          remote_folder ^ "/html/tailwind/packages/./";
+          ".";
+          remote_folder ^ "html/tailwind/packages/./";
         |] )
   in
   let* () = Current.Switch.turn_off switch in

--- a/src/lib/indexes.ml
+++ b/src/lib/indexes.ml
@@ -75,8 +75,8 @@ module Index = struct
   let* () = Current.Job.use_pool ~switch job Remote_cache.ssh_pool in
   let* () = Current.Job.start ~level:Mostly_harmless job in
   let* _ =
-    Current.Process.exec ~cancellable:true ~job
-      ( Fpath.to_string state_dir,
+    Current.Process.exec ~cancellable:true ~cwd:state_dir ~job
+      ( "",
         [|
           "rsync";
           "-avzR";

--- a/src/lib/indexes.ml
+++ b/src/lib/indexes.ml
@@ -94,6 +94,6 @@ module StatCache = Current_cache.Output (Index)
 
 let v ~ssh ~package_name ~statuses : unit Current.t =
   let open Current.Syntax in
-  Current.component "set-status" |>
+  Current.component "set-status for %s" package_name |>
   let> statuses = statuses in
   StatCache.set ssh package_name statuses

--- a/src/lib/remote_cache.mli
+++ b/src/lib/remote_cache.mli
@@ -3,6 +3,8 @@ type t
  Basically it's a way to tell the pipeline if something gets deleted on the storage server, or needs to be rebuilt. 
 *)
 
+val ssh_pool : unit Current.Pool.t
+
 type cache_key = string 
 
 type digest = string


### PR DESCRIPTION
Adds a `state.json` file per package (not per package.version), containing a list of the statuses of the other versions - either successfully built, building or failed. Coupled with some client-side javascript this will allow a dropdown showing links to the other versions of a package, including lights to show whether they have succeeded or not.