### PR TITLE
Compile step: store HTML output in a git repository

### DIFF
--- a/src/docs_ci.ml
+++ b/src/docs_ci.ml
@@ -7,6 +7,13 @@ let monthly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 30) ()
 let program_name = "docs-ci"
 
 let main current_config mode gql_port config =
+  let () =
+    match Docs_ci_lib.Init.setup (Docs_ci_lib.Config.ssh config) with
+    | Ok () -> ()
+    | Error (`Msg msg) ->
+        Docs_ci_lib.Log.err (fun f -> f "Failed to initialize the storage server.");
+        exit 1
+  in
   let repo_opam = Git.clone ~schedule:monthly "https://github.com/ocaml/opam-repository.git" in
   let api = Docs_ci_lib.Web.make config in
   let engine =

--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -121,7 +121,8 @@ module Ssh = struct
 
   let docs_public_endpoint t = t.html_endpoint
 
-  let digest t = Fmt.str "%s-%s-%d-%s" t.host t.user t.port t.folder |> Digest.string |> Digest.to_hex
+  let digest t =
+    Fmt.str "%s-%s-%d-%s" t.host t.user t.port t.folder |> Digest.string |> Digest.to_hex
 end
 
 type t = {

--- a/src/lib/git_store.ml
+++ b/src/lib/git_store.ml
@@ -1,0 +1,18 @@
+let remote t = Fmt.str "%s@%s:%s/git" (Config.Ssh.user t) (Config.Ssh.host t) (Config.Ssh.storage_folder t)
+
+let git_checkout_or_create b =
+  Fmt.str
+    "(git remote set-branches --add origin %s && git fetch origin %s && git checkout --track \
+     origin/%s) || (git checkout -b %s && git push --set-upstream origin %s)"
+    b b b b b
+
+module Cluster = struct
+  let clone ~branch ~directory t =
+    Obuilder_spec.run ~network:[ "host" ] ~secrets:Config.Ssh.secrets
+      "git clone --single-branch %s %s && cd %s && (%s)" (remote t) directory directory
+      (git_checkout_or_create branch)
+
+  let push ?(force = false) _ =
+    Obuilder_spec.run ~network:[ "host" ] ~secrets:Config.Ssh.secrets
+      (if force then "git push -f" else "git push")
+end

--- a/src/lib/git_store.mli
+++ b/src/lib/git_store.mli
@@ -1,0 +1,10 @@
+
+
+module Cluster : sig
+  val clone : branch:string -> directory:string -> Config.Ssh.t -> Obuilder_spec.op
+
+  val push : ?force:bool -> Config.Ssh.t -> Obuilder_spec.op
+
+end
+
+val remote : Config.Ssh.t -> string

--- a/src/lib/init.ml
+++ b/src/lib/init.ml
@@ -1,0 +1,36 @@
+open Config
+
+let ssh_run_prefix ssh =
+  let remote = Ssh.user ssh ^ "@" ^ Ssh.host ssh in
+  Bos.Cmd.(
+    v "ssh" % "-o" % "StrictHostKeyChecking=no" % "-p"
+    % (Ssh.port ssh |> string_of_int)
+    % "-i"
+    % p (Ssh.priv_key_file ssh)
+    % remote)
+
+let setup ssh =
+  Log.app (fun f -> f "Checking storage server status..");
+  let ensure_dir dir =
+    let path = Fpath.(v (Ssh.storage_folder ssh) / dir) in
+    Fmt.str "mkdir -p %a" Fpath.pp path
+  in
+  let ensure_program program = Fmt.str "%s --version" program in
+  let ensure_git_repo dir =
+    let path = Fpath.(v (Ssh.storage_folder ssh) / dir) in
+    Fmt.str "cd %a && (git rev-parse --git-dir || git init --bare)" Fpath.pp path
+  in
+  let run cmd =
+    let cmd = Bos.Cmd.(ssh_run_prefix ssh % cmd) in
+    Bos.OS.Cmd.run cmd
+  in
+
+  let ( let* ) = Result.bind in
+  let ( let+ ) a b = Result.map b a in
+  let* () = ensure_dir "cache" |> run in
+  let* () = ensure_dir "compile" |> run in
+  let* () = ensure_dir "prep" |> run in
+  let* () = ensure_program "git" |> run in
+  let* () = ensure_program "rsync" |> run in
+  let+ () = ensure_git_repo "git" |> run in
+  Log.app (fun f -> f "..OK!")

--- a/src/lib/init.mli
+++ b/src/lib/init.mli
@@ -1,0 +1,1 @@
+val setup : Config.Ssh.t -> (unit, Rresult.R.msg) result


### PR DESCRIPTION
Instead of `rsync`ing, it stores the data in `<storage folder>/git`  and updates a `live` branch which is the merge of all html sources branches. 

I've also added an init step to make sure that the storage server is correctly configured.

