### PR TITLE
Decouple blessed packages calculation

### DIFF
--- a/src/lib/compile.ml
+++ b/src/lib/compile.ml
@@ -235,7 +235,6 @@ let v ~config ~name ~voodoo ~cache ~blessed ~deps prep =
      and> blessed = blessed
      and> deps = deps in
      let package = Prep.package prep in
-     let blessed = Package.Blessed.is_blessed blessed package in
      let opam = package |> Package.opam in
      let version = opam |> OpamPackage.version_to_string in
      let compile_folder = folder ~blessed package in

--- a/src/lib/compile.mli
+++ b/src/lib/compile.mli
@@ -34,7 +34,7 @@ val v :
   config:Config.t ->
   voodoo:Voodoo.Do.t Current.t ->
   cache:Remote_cache.t Current.t ->
-  blessed:Package.Blessed.t Current.t ->
+  blessed:bool Current.t ->
   deps:t list Current.t ->
   Prep.t Current.t ->
   t Current.t


### PR DESCRIPTION
Instead of centralizing the "blessed" calculation into a single `Package.Blessed.t Current.t`, the computation is decoupled using `Package.Blessed.t Current.t OpamPackage.Map.t`.  