### PR TITLE
Make the indexes job push on git + a fix on the git output of the compile step

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,8 @@ services:
 
   init:
     build:
-      dockerfile: Dockerfile
-      context: ./docker/init/
+      dockerfile: docker/init/Dockerfile
+      context: .
     environment:
       - KEYFILE=/ssh/id_ed25519
       - KEYTYPE=ed25519
@@ -47,8 +47,8 @@ services:
 
   storage-server:
     build:
-      dockerfile: Dockerfile
-      context: ./docker/storage/
+      dockerfile: docker/storage/Dockerfile
+      context: .
     depends_on:
       - "init"
     ports:
@@ -59,8 +59,8 @@ services:
 
   git-http:
     build:
-      dockerfile: Dockerfile
-      context: ./docker/git-http
+      dockerfile: docker/git-http/Dockerfile
+      context: .
     ports:
       - "8001:80"
     volumes:

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,3 +1,7 @@
+# Helper dockerfiles
+
+They must be built using the root of the project as context: `docker build -f docker/storage/Dockerfile .`.
+
 ## storage
 
 The server in charge of storing the data:

--- a/docker/git-http/Dockerfile
+++ b/docker/git-http/Dockerfile
@@ -12,8 +12,9 @@ RUN set -x && \
   ln -sf /dev/stdout /var/log/nginx/access.log          &&  \
   ln -sf /dev/stderr /var/log/nginx/error.log
 
-ADD ./etc /etc
-ADD ./entrypoint.sh /usr/local/bin/entrypoint
+
+ADD ./docker/git-http/etc /etc
+ADD ./docker/git-http/entrypoint.sh /usr/local/bin/entrypoint
 
 ENTRYPOINT [ "entrypoint" ]
 CMD [ "-start" ]

--- a/docker/init/Dockerfile
+++ b/docker/init/Dockerfile
@@ -3,5 +3,5 @@ RUN apk add --no-cache \
   openssh-client \
   ca-certificates \
   bash
-ADD init.sh /
+ADD ./docker/init/init.sh /
 CMD /init.sh

--- a/docker/storage/Dockerfile
+++ b/docker/storage/Dockerfile
@@ -15,7 +15,7 @@ RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so
 RUN echo "export VISIBLE=now" >> /etc/profile
 RUN git config --global user.email "docker@ci"
 RUN git config --global user.name "CI"
-COPY entrypoint.sh /entrypoint.sh
+COPY ./docker/storage/entrypoint.sh /entrypoint.sh
 RUN chmod 744 /entrypoint.sh
 
 EXPOSE 22

--- a/src/lib/compile.ml
+++ b/src/lib/compile.ml
@@ -188,7 +188,9 @@ module Compile = struct
                   let git_merge_base = Fmt.str "git merge-base %s %s" live_ref update_ref in
                   (* perform an aggressive merge *)
                   let git_merge_trees =
-                    Fmt.str "git read-tree --empty && git read-tree -mi --aggressive $(%s) %s %s"
+                    Fmt.str
+                      "git read-tree --empty && git read-tree -mi --aggressive $(%s) %s %s && git \
+                       merge-index ~/git-take-theirs.sh -a"
                       git_merge_base live_ref update_ref
                   in
                   (* create a commit object using the newly created tree *)

--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -74,7 +74,10 @@ module Ssh = struct
       user;
       port;
       private_key = load_file privkey;
-      private_key_file = privkey;
+      private_key_file =
+        Fpath.(
+          (Bos.OS.Dir.current () |> Result.get_ok) // (of_string privkey |> Result.get_ok)
+          |> to_string);
       public_key = load_file pubkey;
       folder;
       html_endpoint = endpoint;

--- a/src/lib/git_store.ml
+++ b/src/lib/git_store.ml
@@ -1,4 +1,5 @@
-let remote t = Fmt.str "%s@%s:%s/git" (Config.Ssh.user t) (Config.Ssh.host t) (Config.Ssh.storage_folder t)
+let remote t =
+  Fmt.str "%s@%s:%s/git" (Config.Ssh.user t) (Config.Ssh.host t) (Config.Ssh.storage_folder t)
 
 let git_checkout_or_create b =
   Fmt.str
@@ -15,4 +16,20 @@ module Cluster = struct
   let push ?(force = false) _ =
     Obuilder_spec.run ~network:[ "host" ] ~secrets:Config.Ssh.secrets
       (if force then "git push -f" else "git push")
+end
+
+module Local = struct
+  let clone ~branch ~directory t =
+    Bos.Cmd.(
+      v "env"
+      % Fmt.str "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no -p %d -i %a" (Config.Ssh.port t)
+          Fpath.pp (Config.Ssh.priv_key_file t)
+      % "git" % "clone" % "--single-branch" % "-b" % branch % remote t % p directory)
+
+  let push ~directory t =
+    Bos.Cmd.(
+      v "env"
+      % Fmt.str "GIT_SSH_COMMAND=ssh -o StrictHostKeyChecking=no -p %d -i %a" (Config.Ssh.port t)
+          Fpath.pp (Config.Ssh.priv_key_file t)
+      % "git" % "-C" % p directory % "push")
 end

--- a/src/lib/git_store.mli
+++ b/src/lib/git_store.mli
@@ -7,4 +7,11 @@ module Cluster : sig
 
 end
 
+module Local : sig 
+  val clone : branch:string -> directory:Fpath.t -> Config.Ssh.t -> Bos.Cmd.t
+
+  val push : directory:Fpath.t -> Config.Ssh.t -> Bos.Cmd.t
+
+end
+
 val remote : Config.Ssh.t -> string

--- a/src/lib/indexes.ml
+++ b/src/lib/indexes.ml
@@ -18,9 +18,22 @@ module Index = struct
   end
 
   module Value = struct
-    type t = (string * Web.Status.t) list
+    type t = Web.Status.t OpamPackage.Version.Map.t OpamPackage.Name.Map.t
 
-    let digest v = Format.asprintf "%a" (Fmt.list (Fmt.pair Format.pp_print_string Web.Status.pp)) v
+    let digest v =
+      let digest = ref "" in
+      OpamPackage.Name.Map.iter
+        (fun name versions ->
+          OpamPackage.Version.Map.iter
+            (fun version status ->
+              digest :=
+                Digest.string
+                  (Fmt.str "%s-%s-%s-%a" !digest (OpamPackage.Name.to_string name)
+                     (OpamPackage.Version.to_string version)
+                     Web.Status.pp status))
+            versions)
+        v;
+      !digest
   end
 
   let pp f (package_name, _) = Fmt.pf f "Status update package %s" package_name
@@ -49,52 +62,62 @@ module Index = struct
     in
     ()
 
-let sync_pool = Current.Pool.create ~label:"ssh" 1
-  let publish ssh job package_name v =
-    let open Lwt.Syntax in
+  let sync_pool = Current.Pool.create ~label:"ssh" 1
+
+  let write_state name versions =
+    let package_name = OpamPackage.Name.to_string name in
     let dir = Fpath.(state_dir / package_name) in
     Sys.command (Format.asprintf "mkdir -p %a" Fpath.pp dir) |> ignore;
     let file = Fpath.(dir / "state.json") in
     let ts =
-      List.map
-        (fun (version, status) ->
+      OpamPackage.Version.Map.mapi
+        (fun version status ->
+          let version = OpamPackage.Version.to_string version in
           {
             version;
             link = Format.asprintf "/tailwind/packages/%s/%s/index.html" package_name version;
             status = Fmt.to_to_string Web.Status.pp status;
           })
-        v
+        versions
+      |> OpamPackage.Version.Map.values
     in
     let j = v_list_to_yojson ts in
     let f = open_out (Fpath.to_string file) in
     output_string f (Yojson.Safe.to_string j);
-    close_out f;
-    let remote_folder =
-      Fmt.str "%s@@%s:%s/" (Config.Ssh.user ssh) (Config.Ssh.host ssh)
-        (Config.Ssh.storage_folder ssh)
-    in
-    let switch = Current.Switch.create ~label:"ssh" () in
+    close_out f
+
+  let initialize_state ~job ~ssh () =
+    let open Lwt.Syntax in
+    if Bos.OS.Path.exists Fpath.(state_dir / ".git") |> Result.get_ok then Lwt.return_ok ()
+    else
+      Current.Process.exec ~cancellable:false ~job
+          ( "",
+            Git_store.Local.clone ~branch:"status" ~directory:state_dir ssh
+            |> Bos.Cmd.to_list |> Array.of_list )
+
+  let publish ssh job _ v =
+    let open Lwt.Syntax in
+    let (let**) = Lwt_result.bind in
+    let switch = Current.Switch.create ~label:"sync" () in
     let* () = Current.Job.start_with ~pool:sync_pool ~level:Mostly_harmless job in
     Lwt.finalize
       (fun () ->
+        let** () = initialize_state ~job ~ssh () in
+        (* TODO: only write file on change *)
+        OpamPackage.Name.Map.iter write_state v;
+        let** () =
+          Current.Process.exec ~cancellable:true ~cwd:state_dir ~job
+            ("", [| "bash"; "-c"; Fmt.str "git add --all && (git diff HEAD --exit-code --quiet || git commit -m 'update status')" |])
+        in
         Current.Process.exec ~cancellable:true ~job
-          ( "",
-            [|
-              "rsync";
-              "-avzR";
-              "-e";
-              Fmt.str "ssh -o StrictHostKeyChecking=no -p %d -i %a" (Config.Ssh.port ssh) Fpath.pp
-                (Config.Ssh.priv_key_file ssh);
-              Fpath.to_string state_dir;
-              remote_folder ^ "html/tailwind/packages/./";
-            |] ))
+          ("", Git_store.Local.push ~directory:state_dir ssh |> Bos.Cmd.to_list |> Array.of_list))
       (fun () -> Current.Switch.turn_off switch)
 end
 
 module StatCache = Current_cache.Output (Index)
 
-let v ~ssh ~package_name ~statuses : unit Current.t =
+let v ~ssh ~statuses : unit Current.t =
   let open Current.Syntax in
-  Current.component "set-status for %s" package_name
+  Current.component "set-status"
   |> let> statuses = statuses in
-     StatCache.set ssh package_name statuses
+     StatCache.set ssh "" statuses

--- a/src/lib/init.ml
+++ b/src/lib/init.ml
@@ -36,8 +36,9 @@ let setup ssh =
       "git init --bare && \
       echo 'ref: refs/heads/main' > HEAD && \
       COMMIT=$(git commit-tree $(git write-tree) -m 'root') && \
-      git update-ref refs/heads/main $COMMIT && \
-      git update-ref refs/heads/live $COMMIT"
+      git update-ref refs/heads/main   $COMMIT && \
+      git update-ref refs/heads/live   $COMMIT && \
+      git update-ref refs/heads/status $COMMIT"
     in
     let path = Fpath.(v (Ssh.storage_folder ssh) / dir) in
     Fmt.str "cd %a && (git rev-parse --git-dir || (%s))" Fpath.pp path git_init_command

--- a/src/lib/init.ml
+++ b/src/lib/init.ml
@@ -9,6 +9,21 @@ let ssh_run_prefix ssh =
     % p (Ssh.priv_key_file ssh)
     % remote)
 
+
+
+(*    
+$1 - original file SHA1 (or empty)
+$2 - file in branch1 SHA1 (or empty)
+$3 - file in branch2 SHA1 (or empty)
+$4 - pathname in repository
+$5 - original file mode (or empty)
+$6 - file in branch1 mode (or empty)
+$7 - file in branch2 mode (or empty)
+*)
+let ssh_server_git_merge_script = 
+  let script = {|#!/bin/sh\ngit update-index --cacheinfo "$7","$3","$4"\n|} in
+  Fmt.str "printf '%s' > ~/git-take-theirs.sh && chmod +x ~/git-take-theirs.sh" script
+
 let setup ssh =
   Log.app (fun f -> f "Checking storage server status..");
   let ensure_dir dir =
@@ -40,5 +55,6 @@ let setup ssh =
   let* () = ensure_dir "prep" |> run in
   let* () = ensure_program "git" |> run in
   let* () = ensure_program "rsync" |> run in
-  let+ () = ensure_git_repo "git" |> run in
+  let* () = ensure_git_repo "git" |> run in
+  let+ () = run ssh_server_git_merge_script in
   Log.app (fun f -> f "..OK!")

--- a/src/lib/solver.ml
+++ b/src/lib/solver.ml
@@ -56,7 +56,6 @@ let perform_solve ~solver ~pool ~job ~(platform : Platform.t) ~opam track =
           let solution =
             List.map
               (fun (a, b) ->
-                Current.Job.log job "%s: %s" a (String.concat "; " b);
                 (OpamPackage.of_string a, List.map OpamPackage.of_string b))
               x.packages
           in

--- a/src/pipelines/docs.ml
+++ b/src/pipelines/docs.ml
@@ -81,9 +81,15 @@ let collapse_by ~key ~input (criteria : 'k -> string) (list : ('k * 'v Current.t
   |> StringMap.mapi (fun k v ->
          let curr = List.map snd v in
          let keys = List.map fst v in
-         let current = Current.collapse_list ~key:(key ^ " " ^ k) ~value:"" ~input curr in
+         let current, _ = Current.collapse_list ~key:(key ^ " " ^ k) ~value:"" ~input curr in
          List.combine keys current)
   |> StringMap.bindings |> List.rev_map snd |> List.flatten
+
+let collapse_single ~key ~input list =
+  let curr = List.map snd list in
+  let keys = List.map fst list in
+  let current, node = Current.collapse_list ~key ~value:"" ~input curr in
+  (List.combine keys current, node)
 
 let prep_hierarchical_collapse ~input lst =
   let key = "prep" in
@@ -92,7 +98,7 @@ let prep_hierarchical_collapse ~input lst =
   |> collapse_by ~key ~input (fun x ->
          let name = x.Jobs.install |> Package.opam |> OpamPackage.name_to_string in
          String.sub name 0 1 |> String.uppercase_ascii)
-  |> collapse_by ~key ~input (fun _ -> "")
+  |> collapse_single ~key ~input
 
 let compile_hierarchical_collapse ~input lst =
   let key = "compile" in
@@ -103,7 +109,7 @@ let compile_hierarchical_collapse ~input lst =
   |> collapse_by ~key ~input (fun x ->
          let name = x |> Package.opam |> OpamPackage.name_to_string in
          String.sub name 0 1 |> String.uppercase_ascii)
-  |> collapse_by ~key ~input (fun _ -> "")
+  |> collapse_single ~key ~input
 
 let v ~config ~api ~opam () =
   let open Current.Syntax in
@@ -129,23 +135,19 @@ let v ~config ~api ~opam () =
   (* 4) Schedule a somewhat small set of jobs to obtain at least one universe for each package.version *)
   let jobs = Jobs.schedule ~targets:all_packages all_packages_jobs in
   (* 5) Run the preparation step *)
-  let prepped =
+  let prepped, prepped_input_node =
     jobs
     |> List.map (fun job -> (job, Prep.v ~config ~cache ~voodoo:v_prep job))
     |> prep_hierarchical_collapse ~input:(Current.pair solver_result cache)
+  in
+  let prepped =
+    prepped
     |> List.map (fun (job, result) ->
            job.Jobs.prep |> List.to_seq
            |> Seq.map (fun p -> (p, [ Current.map (Package.Map.find p) result ]))
            |> Package.Map.of_seq)
     |> List.fold_left (Package.Map.union (fun _ a b -> Some (a @ b))) Package.Map.empty
     |> Package.Map.map take_any_success
-  in
-  let prep_list =
-    Package.Map.bindings prepped
-    |> List.rev_map (fun (package, prep) ->
-           let+ prep = Current.state ~hidden:true prep in
-           (package, prep))
-    |> Current.list_seq
   in
   (* 6) Promote packages to the main tree *)
   let blessed =
@@ -173,10 +175,13 @@ let v ~config ~api ~opam () =
   in
 
   (* 7) Odoc compile and html-generate artifacts *)
-  let compiled =
-    compile ~config ~cache ~voodoo:v_do ~blessed prepped
-    |> compile_hierarchical_collapse ~input:prep_list
-    |> List.to_seq |> Package.Map.of_seq
+  let compiled, compiled_input_node =
+    let c, cn = 
+      compile ~config ~cache ~voodoo:v_do ~blessed prepped
+      |> compile_hierarchical_collapse ~input:prepped_input_node
+    in
+    c |> List.to_seq |> Package.Map.of_seq, cn
+
   in
   (* 8) Report status *)
   let package_registry =
@@ -211,7 +216,7 @@ let v ~config ~api ~opam () =
     package_status
     |> Package.Map.mapi (fun package status ->
            Web.set_package_status ~package:(Current.return package) ~status api)
-    |> Package.Map.bindings |> List.map snd |> Current.all
+    |> Package.Map.bindings |> List.map snd |> Current.all |> Current.collapse ~input:compiled_input_node ~key:"Set status (graphql)" ~value:""
   in
   let status2 =
     let package_versions =
@@ -231,5 +236,9 @@ let v ~config ~api ~opam () =
     in
     let ssh = Config.ssh config in
     Indexes.v ~ssh ~statuses
+    |> Current.collapse ~input:compiled_input_node ~key:"Set status (git)" ~value:""
   in
-  Current.all [ package_registry; status; status2 ]
+  Current.all
+    [
+      package_registry; status; status2;
+    ]


### PR DESCRIPTION
It will push on a `status` branch which contains the status of all opam packages. 

The fix is simple that changing which package is blessed would result in a merge conflict. So now in that situation a `git merge-index` script is used to resolve the conflict