### PR TITLE
Separate do and gen

### DIFF
--- a/src/lib/compile.ml
+++ b/src/lib/compile.ml
@@ -29,7 +29,7 @@ let linked_folder ~blessed package = Fpath.(v "linked" // base_folder ~blessed p
 let import_compile_deps ~ssh t =
   let branches =
     List.map
-      (fun { package; hashes = { compile_commit_hash }; _ } ->
+      (fun { package; hashes = { compile_commit_hash; _ }; _ } ->
         (Git_store.Branch.v package, `Commit compile_commit_hash))
       t
   in

--- a/src/lib/compile.ml
+++ b/src/lib/compile.ml
@@ -14,8 +14,6 @@ let is_blessed t = t.blessed
 
 let package t = t.package
 
-let network = Misc.network
-
 let base_folder ~blessed package =
   let universe = Package.universe package |> Package.Universe.hash in
   let opam = Package.opam package in
@@ -68,10 +66,9 @@ let spec ~ssh ~cache_key ~base ~voodoo ~deps ~blessed prep =
          run "rm -f compile/packages/%s/*.odoc" name;
          (* Import odoc and voodoo-do *)
          copy ~from:(`Build "tools")
-           [ "/home/opam/odoc"; "/home/opam/voodoo-do"; "/home/opam/voodoo-gen" ]
+           [ "/home/opam/odoc"; "/home/opam/voodoo-do" ]
            ~dst:"/home/opam/";
          run "mv ~/odoc $(opam config var bin)/odoc";
-         run "cp ~/voodoo-gen $(opam config var bin)/voodoo-gen";
          (* Run voodoo-do *)
          run "OCAMLRUNPARAM=b opam exec -- /home/opam/voodoo-do -p %s %s" name
            (if blessed then "-b" else "");

--- a/src/lib/compile.mli
+++ b/src/lib/compile.mli
@@ -10,10 +10,6 @@ type hashes = {
   compile_tree_hash : string;
   linked_commit_hash : string;
   linked_tree_hash : string;
-  html_tailwind_commit_hash : string;
-  html_tailwind_tree_hash : string;
-  html_classic_commit_hash : string;
-  html_classic_tree_hash : string;
 }
 
 type t
@@ -32,8 +28,8 @@ val package : t -> Package.t
 val folder : t -> Fpath.t
 (** 
 The location where the package is compiled: 
- - If blessed, it's compile/packages/<name>/<version>/
- - If not, it's compile/universes/<universe id>/<name>/<version>/ *)
+ - If blessed, it's packages/<name>/<version>/
+ - If not, it's universes/<universe id>/<name>/<version>/ *)
 
 val v :
   config:Config.t ->

--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -134,6 +134,7 @@ type t = {
   take_n_last_versions : int option;
   ocluster_connection_prep : Current_ocluster.Connection.t;
   ocluster_connection_do : Current_ocluster.Connection.t;
+  ocluster_connection_gen : Current_ocluster.Connection.t;
   ssh : Ssh.t;
 }
 
@@ -164,6 +165,7 @@ let v cap_file jobs track_packages take_n_last_versions ssh =
 
   let ocluster_connection_prep = Current_ocluster.Connection.create ~max_pipeline:100 cap in
   let ocluster_connection_do = Current_ocluster.Connection.create ~max_pipeline:100 cap in
+  let ocluster_connection_gen = Current_ocluster.Connection.create ~max_pipeline:100 cap in
 
   {
     jobs;
@@ -171,6 +173,7 @@ let v cap_file jobs track_packages take_n_last_versions ssh =
     take_n_last_versions;
     ocluster_connection_prep;
     ocluster_connection_do;
+    ocluster_connection_gen;
     ssh;
   }
 
@@ -190,5 +193,7 @@ let take_n_last_versions t = t.take_n_last_versions
 let ocluster_connection_do t = t.ocluster_connection_do
 
 let ocluster_connection_prep t = t.ocluster_connection_prep
+
+let ocluster_connection_gen t = t.ocluster_connection_gen
 
 let ssh t = t.ssh

--- a/src/lib/config.mli
+++ b/src/lib/config.mli
@@ -42,6 +42,9 @@ val ocluster_connection_prep : t -> Current_ocluster.Connection.t
 val ocluster_connection_do : t -> Current_ocluster.Connection.t
 (** Connection to the cluster for Do *)
 
+val ocluster_connection_gen : t -> Current_ocluster.Connection.t
+(** Connection to the cluster for Gen *)
+
 val jobs : t -> int
 (** Number of jobs that can be spawned for the steps that are locally executed. *)
 

--- a/src/lib/html.ml
+++ b/src/lib/html.ml
@@ -1,0 +1,172 @@
+type hashes = {
+  html_tailwind_commit_hash : string;
+  html_tailwind_tree_hash : string;
+  html_classic_commit_hash : string;
+  html_classic_tree_hash : string;
+}
+[@@deriving yojson]
+
+type t = { package : Package.t; blessed : bool; hashes : hashes }
+
+let hashes t = t.hashes
+
+let is_blessed t = t.blessed
+
+let package t = t.package
+
+
+let base_folder ~blessed package =
+  let universe = Package.universe package |> Package.Universe.hash in
+  let opam = Package.opam package in
+  let name = OpamPackage.name_to_string opam in
+  let version = OpamPackage.version_to_string opam in
+  if blessed then Fpath.(v "packages" / name / version)
+  else Fpath.(v "universes" / universe / name / version)
+
+let tailwind_folder ~blessed package = Fpath.(v "tailwind" // base_folder ~blessed package)
+
+let classic_folder ~blessed package = Fpath.(v "html" // base_folder ~blessed package)
+
+let spec ~ssh ~cache_key ~base ~voodoo ~blessed compiled =
+  let open Obuilder_spec in
+  let package = Compile.package compiled in
+  let commit = (Compile.hashes compiled).linked_commit_hash in
+  let tailwind_folder = tailwind_folder ~blessed package in
+  let classic_folder = classic_folder ~blessed package in
+  let branch = Git_store.Branch.v package in
+  let opam = package |> Package.opam in
+  let name = opam |> OpamPackage.name_to_string in
+  let version = opam |> OpamPackage.version_to_string in
+  let message = Fmt.str "docs ci update %s\n\n%s" (Fmt.to_to_string Package.pp package) cache_key in
+  let tools = Voodoo.Gen.spec ~base voodoo |> Spec.finish in
+  base |> Spec.children ~name:"tools" tools
+  |> Spec.add
+       [
+         workdir "/home/opam/docs/";
+         run "sudo chown opam:opam . ";
+         (* obtain the linked folder *)
+         Git_store.Cluster.pull_to_directory ~repository:Linked ~ssh ~directory:"linked"
+           ~branches:[ (branch, `Commit commit) ];
+         run "find .";
+         (* Import odoc and voodoo-do *)
+         copy ~from:(`Build "tools")
+           [ "/home/opam/odoc"; "/home/opam/voodoo-gen" ]
+           ~dst:"/home/opam/";
+         run "mv ~/odoc $(opam config var bin)/odoc";
+         run "cp ~/voodoo-gen $(opam config var bin)/voodoo-gen";
+         (* Run voodoo-do *)
+         run
+           "OCAMLRUNPARAM=b opam exec -- /home/opam/voodoo-gen pkgver -o tailwind -n %s \
+            --pkg-version %s"
+           name version;
+         run
+           "opam exec -- bash -c 'for i in $(find linked -name *.odocl); do odoc html-generate $i \
+            -o html; done'";
+         run "%s" @@ Fmt.str "mkdir -p %a" Fpath.pp tailwind_folder;
+         run "%s" @@ Fmt.str "mkdir -p %a" Fpath.pp classic_folder;
+         (* Extract compile output   - cache needs to be invalidated if we want to be able to read the logs *)
+         run "echo '%f'" (Random.float 1.);
+         (* Extract html/tailwind output *)
+         Git_store.Cluster.write_folder_to_git ~repository:HtmlTailwind ~ssh ~branch
+           ~folder:"tailwind" ~message ~git_path:"/tmp/git-html-tailwind";
+         (* Extract html output*)
+         Git_store.Cluster.write_folder_to_git ~repository:HtmlClassic ~ssh ~branch ~folder:"html"
+           ~message ~git_path:"/tmp/git-html-classic";
+         run "cd /tmp/git-html-tailwind && %s"
+           (Git_store.print_branches_info ~prefix:"TAILWIND" ~branches:[ branch ]);
+         run "cd /tmp/git-html-classic && %s"
+           (Git_store.print_branches_info ~prefix:"HTML" ~branches:[ branch ]);
+       ]
+
+let or_default a = function None -> a | b -> b
+
+module Gen = struct
+  type t = No_context
+
+  let id = "voodoo-gen"
+
+  module Value = struct
+    type t = hashes [@@deriving yojson]
+
+    let marshal t = t |> to_yojson |> Yojson.Safe.to_string
+
+    let unmarshal t = t |> Yojson.Safe.from_string |> of_yojson |> Result.get_ok
+  end
+
+  module Key = struct
+    type t = { config : Config.t; compile : Compile.t; voodoo : Voodoo.Gen.t }
+
+    let key { config; compile; voodoo } =
+      Fmt.str "v3-%s-%s-%s-%s"
+        (Compile.package compile |> Package.digest)
+        (Compile.hashes compile).linked_tree_hash (Voodoo.Gen.digest voodoo) (Config.odoc config)
+
+    let digest t = key t |> Digest.string |> Digest.to_hex
+  end
+
+  let pp f Key.{ compile; _ } = Fmt.pf f "Voodoo gen %a" Package.pp (Compile.package compile)
+
+  let auto_cancel = true
+
+  let remote_cache_key Key.{ voodoo; compile; config; _ } =
+    Fmt.str "voodoo-gen-v0-%s-%s-%s-%s"
+      (Compile.package compile |> Package.digest)
+      (Compile.hashes compile).linked_tree_hash (Voodoo.Gen.digest voodoo)
+      (Config.odoc config |> Digest.string |> Digest.to_hex)
+
+  let build No_context job (Key.{ compile; voodoo; config } as key) =
+    let open Lwt.Syntax in
+    let ( let** ) = Lwt_result.bind in
+    let package = Compile.package compile in
+    let blessed = Compile.is_blessed compile in
+    let cache_key = remote_cache_key key in
+    Current.Job.log job "Cache digest: %s" (Key.key key);
+    let base = Misc.get_base_image package in
+    let spec = spec ~ssh:(Config.ssh config) ~cache_key ~voodoo ~base ~blessed compile in
+    let action = Misc.to_ocluster_submission spec in
+    let version = Misc.base_image_version package in
+    let cache_hint = "docs-universe-compile-" ^ version in
+    let build_pool =
+      Current_ocluster.Connection.pool ~job ~pool:(Config.pool config) ~action ~cache_hint
+        ~secrets:(Config.Ssh.secrets_values (Config.ssh config))
+        (Config.ocluster_connection_do config)
+    in
+    let* build_job = Current.Job.start_with ~pool:build_pool ~level:Mostly_harmless job in
+    Current.Job.log job "Using cache hint %S" cache_hint;
+    Capnp_rpc_lwt.Capability.with_ref build_job @@ fun build_job ->
+    let** _ = Current_ocluster.Connection.run_job ~job build_job in
+    let extract_hashes (v_html_tailwind, v_html_classic) line =
+      (* some early stopping could be done here *)
+      let html_tailwind =
+        Git_store.parse_branch_info ~prefix:"TAILWIND" line |> or_default v_html_tailwind
+      in
+      let html_classic =
+        Git_store.parse_branch_info ~prefix:"HTML" line |> or_default v_html_classic
+      in
+      (html_tailwind, html_classic)
+    in
+    let** html_tailwind, html_classic = Misc.fold_logs build_job extract_hashes (None, None) in
+    try
+      let html_tailwind = Option.get html_tailwind in
+      let html_classic = Option.get html_classic in
+
+      Lwt.return_ok
+        {
+          html_tailwind_commit_hash = html_tailwind.commit_hash;
+          html_tailwind_tree_hash = html_tailwind.tree_hash;
+          html_classic_commit_hash = html_classic.commit_hash;
+          html_classic_tree_hash = html_classic.tree_hash;
+        }
+    with Invalid_argument _ -> Lwt.return_error (`Msg "Gen: failed to parse output")
+end
+
+module GenCache = Current_cache.Make (Gen)
+
+let v ~config ~name ~voodoo compile =
+  let open Current.Syntax in
+  Current.component "html %s" name
+  |> let> compile = compile and> voodoo = voodoo in
+     let blessed = Compile.is_blessed compile in
+     let package = Compile.package compile in
+     let output = GenCache.get No_context Gen.Key.{ compile; voodoo; config } in
+     Current.Primitive.map_result (Result.map (fun hashes -> { package; blessed; hashes })) output

--- a/src/lib/html.ml
+++ b/src/lib/html.ml
@@ -129,7 +129,7 @@ module Gen = struct
     let build_pool =
       Current_ocluster.Connection.pool ~job ~pool:(Config.pool config) ~action ~cache_hint
         ~secrets:(Config.Ssh.secrets_values (Config.ssh config))
-        (Config.ocluster_connection_do config)
+        (Config.ocluster_connection_gen config)
     in
     let* build_job = Current.Job.start_with ~pool:build_pool ~level:Mostly_harmless job in
     Current.Job.log job "Using cache hint %S" cache_hint;

--- a/src/lib/html.ml
+++ b/src/lib/html.ml
@@ -117,15 +117,12 @@ module Gen = struct
   let build No_context job (Key.{ compile; voodoo; config } as key) =
     let open Lwt.Syntax in
     let ( let** ) = Lwt_result.bind in
-    let package = Compile.package compile in
     let blessed = Compile.is_blessed compile in
     let cache_key = remote_cache_key key in
     Current.Job.log job "Cache digest: %s" (Key.key key);
-    let base = Misc.get_base_image package in
-    let spec = spec ~ssh:(Config.ssh config) ~cache_key ~voodoo ~base ~blessed compile in
+    let spec = spec ~ssh:(Config.ssh config) ~cache_key ~voodoo ~base:Misc.default_base_image ~blessed compile in
     let action = Misc.to_ocluster_submission spec in
-    let version = Misc.base_image_version package in
-    let cache_hint = "docs-universe-compile-" ^ version in
+    let cache_hint = "docs-universe-gen" in
     let build_pool =
       Current_ocluster.Connection.pool ~job ~pool:(Config.pool config) ~action ~cache_hint
         ~secrets:(Config.Ssh.secrets_values (Config.ssh config))

--- a/src/lib/html.mli
+++ b/src/lib/html.mli
@@ -1,0 +1,33 @@
+(** Compilation step
+
+The documentation compilation is done as an ocluster. It takes for input one prep/ folder and its
+compiled dependencies. It uses `voodoo-do` to perform the compilation, link and html generation 
+steps, outputting the results in the compile/ and html/ folders.  
+*)
+
+type hashes = {
+  html_tailwind_commit_hash : string;
+  html_tailwind_tree_hash : string;
+  html_classic_commit_hash : string;
+  html_classic_tree_hash : string;
+}
+
+type t
+(** A compiled package *)
+
+val hashes : t -> hashes
+(** Hash of the compiled artifacts  *)
+
+val is_blessed : t -> bool
+(** A blessed package is compiled in the compile/packages/... hierarchy, whereas a non-blessed 
+ package is compiled in the compile/universes/... hierarchy *)
+
+val package : t -> Package.t
+(** The compiled package *)
+
+val v :
+  config:Config.t ->
+  name:string ->
+  voodoo:Voodoo.Gen.t Current.t ->
+  Compile.t Current.t ->
+  t Current.t

--- a/src/lib/misc.ml
+++ b/src/lib/misc.ml
@@ -14,6 +14,8 @@ let base_image_version package =
 (** Select base image to use *)
 let get_base_image package = Spec.make ("ocaml/opam:ubuntu-ocaml-" ^ base_image_version package)
 
+let default_base_image = Spec.make "ocaml/opam:ubuntu-ocaml-4.12"
+
 let network = [ "host" ]
 
 let docs_cache_folder = "/home/opam/docs-cache/"

--- a/src/lib/pages.ml
+++ b/src/lib/pages.ml
@@ -65,7 +65,7 @@ module Pages = struct
     let build_pool =
       Current_ocluster.Connection.pool ~job ~pool:(Config.pool config) ~action ~cache_hint
         ~secrets:(Config.Ssh.secrets_values (Config.ssh config))
-        (Config.ocluster_connection_do config)
+        (Config.ocluster_connection_gen config)
     in
     let* build_job = Current.Job.start_with ~pool:build_pool ~level:Mostly_harmless job in
     Current.Job.log job "Using cache hint %S" cache_hint;

--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -91,6 +91,7 @@ module Op = struct
     let** voodoo_gen = get_oldest_commit_for ~job ~dir ~from voodoo_gen_paths in
     Current.Job.log job "Prep commit: %s" voodoo_prep;
     Current.Job.log job "Do commit: %s" voodoo_do;
+    Current.Job.log job "Gen commit: %s" voodoo_gen;
     let voodoo_prep = with_hash ~id voodoo_prep in
     let voodoo_do = with_hash ~id voodoo_do in
     let voodoo_gen = with_hash ~id voodoo_gen in

--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -68,7 +68,7 @@ module Op = struct
   let voodoo_do_paths =
     Fpath.[ v "voodoo-do.opam"; v "voodoo-lib.opam"; v "bin/do/"; v "lib/"; v "vendor/" ]
 
-  let voodoo_gen_paths = Fpath.[ v "voodoo-gen.opam"; v "gen"; v "lib/" ]
+  let voodoo_gen_paths = Fpath.[ v "voodoo-gen.opam"; v "gen/"; v "lib/"; v "web/"; v "styles/" ]
 
   let get_oldest_commit_for ~job ~dir ~from paths =
     let paths = List.map Fpath.to_string paths in

--- a/src/lib/voodoo.mli
+++ b/src/lib/voodoo.mli
@@ -28,6 +28,20 @@ module Do : sig
   val v : voodoo -> t
 
   val digest : t -> string
-  
+
+  val commit : t -> Current_git.Commit_id.t
+end
+
+module Gen : sig
+  type voodoo = t
+
+  type t
+
+  val spec : base:Spec.t -> t -> Spec.t
+
+  val v : voodoo -> t
+
+  val digest : t -> string
+
   val commit : t -> Current_git.Commit_id.t
 end

--- a/src/pipelines/docs.ml
+++ b/src/pipelines/docs.ml
@@ -55,7 +55,7 @@ let compile ~config ~voodoo_gen ~voodoo_do
     | Some compile ->
         Some
           (Html.v ~config
-             ~name:(package |> Package.opam |> OpamPackage.name_to_string)
+             ~name:(package |> Package.opam |> OpamPackage.to_string)
              ~voodoo:voodoo_gen compile)
   in
   Package.Map.filter_map get_compilation_node preps |> Package.Map.bindings


### PR DESCRIPTION
Introduces a new `Html` module that behaves similarly as compile, except it calls `voodoo-gen` instead of `voodoo-do`. It has a single input, a `Compile.t` which is the output of the `Compile` module. 

The `Voodoo` module has been updated to separately track the `voodoo-gen` package. 

A new ocluster pool has been created for the voodoo-gen jobs