### PR TITLE
tar folders before adding them to git

### DIFF
--- a/src/lib/html.ml
+++ b/src/lib/html.ml
@@ -47,7 +47,7 @@ let spec ~ssh ~cache_key ~base ~voodoo ~blessed compiled =
          (* obtain the linked folder *)
          Git_store.Cluster.pull_to_directory ~repository:Linked ~ssh ~directory:"linked"
            ~branches:[ (branch, `Commit commit) ];
-         run "find .";
+         run "find . -name '*.tar' -exec tar -xvf {} \\;";
          (* Import odoc and voodoo-do *)
          copy ~from:(`Build "tools")
            [ "/home/opam/odoc"; "/home/opam/voodoo-gen" ]

--- a/src/lib/misc.ml
+++ b/src/lib/misc.ml
@@ -106,3 +106,10 @@ let fold_logs build_job fn =
     | line :: next -> aux start next (fn acc line)
   in
   aux 0L []
+
+let tar_cmd folder =
+  let f = Fpath.to_string folder in
+  Fmt.str
+    "shopt -s nullglob && ((tar -cvf %s.tar %s/*  && rm -R %s/* && mv %s.tar %s/content.tar) || \
+     (echo 'Empty directory'))"
+    f f f f f


### PR DESCRIPTION
Instead of having git managing a lot of objects, tar is used to flatten folders into one file (`content.tar`). 

Non-existent or empty folders don't generate a `content.tar` file.

With this scheme, un-tar is easy and yield the original folder structure: `find . -name '*.tar' -exec tar -xvf {} \\;`