### PR TITLE
Update paths to watch in voodoo's directory

### DIFF
--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -63,12 +63,12 @@ module Op = struct
       { voodoo_do; voodoo_prep; voodoo_gen }
   end
 
-  let voodoo_prep_paths = Fpath.[ v "voodoo-prep.opam"; v "bin/prep/" ]
+  let voodoo_prep_paths = Fpath.[ v "voodoo-prep.opam"; v "src/voodoo-prep/" ]
 
   let voodoo_do_paths =
-    Fpath.[ v "voodoo-do.opam"; v "voodoo-lib.opam"; v "bin/do/"; v "lib/"; v "vendor/" ]
+    Fpath.[ v "voodoo-do.opam"; v "voodoo-lib.opam"; v "src/voodoo-do/"; v "src/voodoo/" ]
 
-  let voodoo_gen_paths = Fpath.[ v "voodoo-gen.opam"; v "gen/"; v "lib/"; v "web/"; v "styles/" ]
+  let voodoo_gen_paths = Fpath.[ v "voodoo-gen.opam"; v "src/voodoo-gen/"; v "src/voodoo/"; v "src/voodoo-web/" ]
 
   let get_oldest_commit_for ~job ~dir ~from paths =
     let paths = List.map Fpath.to_string paths in


### PR DESCRIPTION
Companion PR for https://github.com/ocaml-doc/voodoo/pull/21, which reorganizes files in `voodoo`.

**Warning:** Only merge if the PR above is approved and the structure is left as currently proposed.