### PR TITLE
Optimize ocluster jobs 

### DIFF
--- a/src/lib/compile.mli
+++ b/src/lib/compile.mli
@@ -21,6 +21,7 @@ val package : t -> Package.t
 (** The compiled package *)
 
 val v :
+  generation:Epoch.t Current.t ->
   config:Config.t ->
   name:string ->
   voodoo:Voodoo.Do.t Current.t ->

--- a/src/lib/epoch.ml
+++ b/src/lib/epoch.ml
@@ -4,17 +4,28 @@ let version = "v1"
 
 let v config voodoo = { config; voodoo }
 
-let digest t =
+type stage = [ `Linked | `Html ]
+
+let digest stage t =
   let key =
-    Fmt.str "%s:%s:%s:%s" version (Config.odoc t.config)
-      Voodoo.Do.(v t.voodoo |> digest)
-      Voodoo.Prep.(v t.voodoo |> digest)
+    match stage with
+    | `Html ->
+        Fmt.str "%s:%s:%s:%s:%s" version (Config.odoc t.config)
+          Voodoo.Do.(v t.voodoo |> digest)
+          Voodoo.Prep.(v t.voodoo |> digest)
+          Voodoo.Gen.(v t.voodoo |> digest)
+    | `Linked ->
+        Fmt.str "%s:%s:%s:%s" version (Config.odoc t.config)
+          Voodoo.Do.(v t.voodoo |> digest)
+          Voodoo.Prep.(v t.voodoo |> digest)
   in
   key |> Digest.string |> Digest.to_hex
 
 let pp f t =
-  Fmt.pf f "docs-ci: %s\nodoc: %s\nvoodoo do: %a\nvoodoo prep: %a" version (Config.odoc t.config)
-    Current_git.Commit_id.pp
+  Fmt.pf f "docs-ci: %s\nodoc: %s\nvoodoo do: %a\nvoodoo prep: %a\nvoodoo gen: %a" version
+    (Config.odoc t.config) Current_git.Commit_id.pp
     Voodoo.Do.(v t.voodoo |> commit)
     Current_git.Commit_id.pp
     Voodoo.Prep.(v t.voodoo |> commit)
+    Current_git.Commit_id.pp
+    Voodoo.Gen.(v t.voodoo |> commit)

--- a/src/lib/epoch.mli
+++ b/src/lib/epoch.mli
@@ -2,6 +2,8 @@ type t
 
 val v : Config.t -> Voodoo.t -> t
 
-val digest : t -> string
+type stage = [ `Linked | `Html ]
+
+val digest : stage -> t -> string
 
 val pp : t Fmt.t

--- a/src/lib/html.ml
+++ b/src/lib/html.ml
@@ -11,7 +11,7 @@ let package t = t.package
 let spec ~ssh ~generation ~base ~voodoo ~blessed compiled =
   let open Obuilder_spec in
   let package = Compile.package compiled in
-  let linked_folder = Storage.folder (Linked blessed) package in
+  let linked_folder = Storage.folder (Linked (generation, blessed)) package in
   let tailwind_folder = Storage.folder (HtmlTailwind (generation, blessed)) package in
   let classic_folder = Storage.folder (HtmlClassic (generation, blessed)) package in
   let opam = package |> Package.opam in

--- a/src/lib/html.ml
+++ b/src/lib/html.ml
@@ -23,6 +23,13 @@ let spec ~ssh ~generation ~base ~voodoo ~blessed compiled =
        [
          workdir "/home/opam/docs/";
          run "sudo chown opam:opam . ";
+         (* Import odoc and voodoo-do *)
+         copy ~from:(`Build "tools")
+           [ "/home/opam/odoc"; "/home/opam/voodoo-gen" ]
+           ~dst:"/home/opam/";
+         run
+           "mv ~/odoc $(opam config var bin)/odoc && cp ~/voodoo-gen $(opam config var \
+            bin)/voodoo-gen";
          (* obtain the linked folder *)
          run ~network:Misc.network ~secrets:Config.Ssh.secrets
            "rsync -aR %s:%s/./%s %s:%s/./%s/page-%s.odocl . && find . -name '*.tar' -exec tar -xvf \
@@ -31,13 +38,6 @@ let spec ~ssh ~generation ~base ~voodoo ~blessed compiled =
            (Config.Ssh.host ssh) (Config.Ssh.storage_folder ssh)
            Fpath.(to_string (parent linked_folder))
            (Package.opam package |> OpamPackage.version_to_string);
-         (* Import odoc and voodoo-do *)
-         copy ~from:(`Build "tools")
-           [ "/home/opam/odoc"; "/home/opam/voodoo-gen" ]
-           ~dst:"/home/opam/";
-         run
-           "mv ~/odoc $(opam config var bin)/odoc && cp ~/voodoo-gen $(opam config var \
-            bin)/voodoo-gen";
          (* Run voodoo-gen *)
          run
            "OCAMLRUNPARAM=b opam exec -- /home/opam/voodoo-gen pkgver -o %s -n %s --pkg-version %s"

--- a/src/lib/jobs.ml
+++ b/src/lib/jobs.ml
@@ -23,9 +23,11 @@ package.version.universe -> 1 2 3 4 5
 2) For each job, sort by increasing universe size and set `prep` as the never previously encountered packages in the universe.
 
 *)
-let schedule ~(targets : Package.t list) jobs : t list =
+let schedule ~(targets : Package.Set.t) jobs : t list =
   Printf.printf "Schedule %d\n" (List.length jobs);
-  let targets_digests = targets |> List.rev_map Package.digest |> StringSet.of_list in
+  let targets_digests =
+    targets |> Package.Set.to_seq |> Seq.map Package.digest |> StringSet.of_seq
+  in
   let jobs =
     jobs
     |> List.rev_map (fun pkg ->

--- a/src/lib/live.ml
+++ b/src/lib/live.ml
@@ -2,10 +2,16 @@ module Op = struct
   type t = Config.Ssh.t
 
   module Key = Current.Unit
-  module Value = Epoch
+
+  module Value = struct
+    type t = Epoch.t
+
+    let digest = Epoch.digest `Html
+  end
+
   module Outcome = Current.Unit
 
-  let id = ""
+  let id = "set-live-folder"
 
   let pp f (_, v) = Fmt.pf f "Set live folder to %a" Epoch.pp v
 
@@ -15,7 +21,7 @@ module Op = struct
     let open Lwt.Syntax in
     let module Ssh = Config.Ssh in
     let* () = Current.Job.start ~level:Dangerous job in
-    let new_generation_folder = Storage.Base.generation_folder generation in
+    let new_generation_folder = Storage.Base.generation_folder `Html generation in
     let storage_folder = Fpath.(of_string (Ssh.storage_folder ssh) |> Result.get_ok) in
     let target_folder = Fpath.(storage_folder // new_generation_folder) in
     let live_folder = Fpath.(storage_folder / "live") in

--- a/src/lib/misc.ml
+++ b/src/lib/misc.ml
@@ -48,13 +48,13 @@ module LatchedBuilder (B : Current_cache.S.BUILDER) = struct
 
     let id = B.id
 
-    module Key = B.Key
-    module Value = Current.Unit
+    module Key = Current.String
+    module Value = B.Key
     module Outcome = B.Value
 
-    let run op job key () = B.build op job key
+    let run op job _ key = B.build op job key
 
-    let pp f (key, ()) = B.pp f key
+    let pp f (_, key) = B.pp f key
 
     let auto_cancel = B.auto_cancel
 
@@ -63,7 +63,7 @@ module LatchedBuilder (B : Current_cache.S.BUILDER) = struct
 
   include Current_cache.Generic (Adaptor)
 
-  let get ?schedule ctx key = run ?schedule ctx key ()
+  let get ~opkey ?schedule ctx key = run ?schedule ctx opkey key
 end
 
 let profile =

--- a/src/lib/misc.ml
+++ b/src/lib/misc.ml
@@ -113,3 +113,11 @@ let tar_cmd folder =
     "shopt -s nullglob && ((tar -cvf %s.tar %s/*  && rm -R %s/* && mv %s.tar %s/content.tar) || \
      (echo 'Empty directory'))"
     f f f f f
+
+module Cmd = struct
+  let tar = tar_cmd
+
+  let list =
+    let open Fmt in
+    to_to_string (list ~sep:(const string " && ") (fun f -> pf f "(%s)"))
+end

--- a/src/lib/opam_metadata.ml
+++ b/src/lib/opam_metadata.ml
@@ -49,7 +49,7 @@ module Metadata = struct
     Current.Process.exec ~cancellable:false ~job
       ( "",
         Bos.Cmd.(
-          v "rsync" % "-avzR" % "--delete" % "-e"
+          v "rsync" % "-avzR" % "--delete" % "--exclude=\"/*/*/*/*/*/\"" % "-e"
           % Fmt.str "ssh -p %d -i %a" port Fpath.pp privkeyfile
           % Fmt.str "--rsync-path=mkdir -p %s/%a && rsync" root_folder Fpath.pp
               (Storage.Base.folder (HtmlTailwind generation))
@@ -113,7 +113,7 @@ module Metadata = struct
     Current.Process.exec ~cancellable:false ~job
       ( "",
         Bos.Cmd.(
-          v "rsync" % "-avzR" % "-e"
+          v "rsync" % "-avzR" % "--exclude=\"/*/*/*/*/*/\"" % "-e"
           % Fmt.str "ssh -p %d -i %a" port Fpath.pp privkeyfile
           % (Fpath.to_string state_dir ^ "/./")
           % Fmt.str "%s@%s:%s" user host root_folder)

--- a/src/lib/opam_metadata.ml
+++ b/src/lib/opam_metadata.ml
@@ -18,7 +18,7 @@ module Metadata = struct
   module Key = struct
     type t = Epoch.t
 
-    let digest v = Fmt.str "metadata4-%s" (Epoch.digest v)
+    let digest v = Fmt.str "metadata4-%s" (Epoch.digest `Html v)
   end
 
   module Value = struct

--- a/src/lib/package.mli
+++ b/src/lib/package.mli
@@ -16,29 +16,7 @@ and Package : sig
   type t
   (** A package in the docs-ci sense: it's composed of the package name, version, 
   and its dependency universe. *)
-end
 
-and Blessing : sig
-  type t = Blessed | Universe
-
-  val is_blessed : t -> bool
-
-  val to_string : t -> string
-
-  module Set : sig
-    type b = t
-
-    type t
-    (** The structure containing which packages are blessed or not. A blessed package is a package
-    aimed to be built for the main documentation pages. *)
-
-    val empty : OpamPackage.t -> t
-
-    val v : Package.t list -> t
-    (** Compute which packages are blessed. *)
-
-    val get : t -> Package.t -> b
-  end
 end
 
 type t = Package.t
@@ -71,3 +49,26 @@ val id : t -> string
 module Map : Map.S with type key = t
 
 module Set : Set.S with type elt = t
+
+module Blessing : sig
+  type t = Blessed | Universe
+
+  val is_blessed : t -> bool
+
+  val to_string : t -> string
+
+  module Set : sig
+    type b = t
+
+    type t
+    (** The structure containing which packages are blessed or not. A blessed package is a package
+    aimed to be built for the main documentation pages. *)
+
+    val empty : OpamPackage.t -> t
+
+    val v : counts:int Map.t -> Package.t list -> t
+    (** Compute which packages are blessed. *)
+
+    val get : t -> Package.t -> b
+  end
+end

--- a/src/lib/pages.ml
+++ b/src/lib/pages.ml
@@ -17,7 +17,7 @@ let spec ~ssh ~generation ~base ~voodoo ~input_hash () =
            (Config.Ssh.storage_folder ssh)
            (Fpath.to_string (Storage.Base.folder (HtmlTailwind generation))) input_hash;
          run "OCAMLRUNPARAM=b cd %s && opam exec -- /home/opam/voodoo-gen packages -o html-tailwind"
-           (Fpath.to_string (Storage.Base.generation_folder generation));
+           (Fpath.to_string (Storage.Base.generation_folder `Html generation));
          run ~network:Misc.network ~secrets:Config.Ssh.secrets
            "rsync -avzR --exclude=\"/*/*/*/*/*/\" ./%s %s:%s/.  "
            (Fpath.to_string (Storage.Base.folder (HtmlTailwind generation)))

--- a/src/lib/storage.ml
+++ b/src/lib/storage.ml
@@ -1,27 +1,32 @@
 module Base = struct
-  type repository = HtmlTailwind of Epoch.t | HtmlClassic of Epoch.t | Linked | Compile | Prep
+  type repository =
+    | HtmlTailwind of Epoch.t
+    | HtmlClassic of Epoch.t
+    | Linked of Epoch.t
+    | Compile
+    | Prep
 
-  let generation_folder generation = Fpath.(v ("html-g-" ^ Epoch.digest generation))
+  let generation_folder stage generation = Fpath.(v ("epoch-" ^ Epoch.digest stage generation))
 
   let folder = function
-    | HtmlTailwind generation -> Fpath.(generation_folder generation / "html-tailwind")
-    | HtmlClassic generation -> Fpath.(generation_folder generation / "html-classic")
+    | HtmlTailwind generation -> Fpath.(generation_folder `Html generation / "html-tailwind")
+    | HtmlClassic generation -> Fpath.(generation_folder `Html generation / "html-classic")
+    | Linked generation -> Fpath.(generation_folder `Linked generation / "linked")
     | Compile -> Fpath.v "compile"
-    | Linked -> Fpath.v "linked"
     | Prep -> Fpath.v "prep"
 end
 
 type repository =
   | HtmlTailwind of (Epoch.t * Package.Blessing.t)
   | HtmlClassic of (Epoch.t * Package.Blessing.t)
-  | Linked of Package.Blessing.t
+  | Linked of (Epoch.t * Package.Blessing.t)
   | Compile of Package.Blessing.t
   | Prep
 
 let to_base_repo = function
   | HtmlClassic (t, _) -> Base.HtmlClassic t
   | HtmlTailwind (t, _) -> Base.HtmlTailwind t
-  | Linked _ -> Linked
+  | Linked (t, _) -> Linked t
   | Compile _ -> Compile
   | Prep -> Prep
 
@@ -36,7 +41,7 @@ let base_folder ~blessed package =
 let folder repository package =
   let blessed =
     match repository with
-    | HtmlTailwind (_, b) | HtmlClassic (_, b) | Linked b | Compile b -> b
+    | HtmlTailwind (_, b) | HtmlClassic (_, b) | Linked (_, b) | Compile b -> b
     | Prep -> Universe
   in
   let blessed = blessed = Blessed in

--- a/src/lib/storage.mli
+++ b/src/lib/storage.mli
@@ -1,18 +1,23 @@
 type repository =
   | HtmlTailwind of (Epoch.t * Package.Blessing.t)
   | HtmlClassic of (Epoch.t * Package.Blessing.t)
-  | Linked of Package.Blessing.t
+  | Linked of (Epoch.t * Package.Blessing.t)
   | Compile of Package.Blessing.t
   | Prep
 
 val folder : repository -> Package.t -> Fpath.t
 
 module Base : sig
-  type repository = HtmlTailwind of Epoch.t | HtmlClassic of Epoch.t | Linked | Compile | Prep
+  type repository =
+    | HtmlTailwind of Epoch.t
+    | HtmlClassic of Epoch.t
+    | Linked of Epoch.t
+    | Compile
+    | Prep
 
   val folder : repository -> Fpath.t
 
-  val generation_folder : Epoch.t -> Fpath.t
+  val generation_folder : Epoch.stage -> Epoch.t -> Fpath.t
 end
 
 (* [for_all repo packages command] is a command that executes [command] for all [packages] folders in [repo].
@@ -29,7 +34,6 @@ module Tar : sig
   (* print sha256 hash of $1/content.tar or empty if it doesn't exist as following line:
      <prefix>:$HASH:$2*)
   val hash_command : prefix:string -> string
-
 end
 
 (* parse a line created by the previous command *)

--- a/src/lib/track.ml
+++ b/src/lib/track.ml
@@ -21,7 +21,7 @@ module Track = struct
   let auto_cancel = true
 
   module Key = struct
-    type t = { limit: int option; repo : Git.Commit.t; filter : string list }
+    type t = { limit : int option; repo : Git.Commit.t; filter : string list }
 
     let digest { repo; filter; limit } =
       Git.Commit.hash repo ^ String.concat ";" filter ^ "; "
@@ -67,7 +67,9 @@ module Track = struct
     Git.with_checkout ~job repo @@ fun dir ->
     Bos.OS.Dir.contents Fpath.(dir / "packages")
     >>= (fun packages ->
-          packages |> List.filter filter |> List.rev_map (get_versions ~limit) |> List.flatten |> Result.ok)
+          packages |> List.filter filter
+          |> List.rev_map (get_versions ~limit)
+          |> List.flatten |> Result.ok)
     |> Lwt.return
 end
 
@@ -95,4 +97,5 @@ let v ~limit ~(filter : string list) (repo : Git.Commit.t Current.t) =
   let open Current.Syntax in
   Current.component "Track packages - %a" Fmt.(list string) filter
   |> let> repo = repo in
-     TrackCache.get No_context { filter; repo; limit }
+     (* opkey is a constant because we expect only one instance of track *)
+     TrackCache.get ~opkey:"track" No_context { filter; repo; limit }

--- a/src/pipelines/docs.ml
+++ b/src/pipelines/docs.ml
@@ -44,7 +44,8 @@ let compile ~generation ~config ~voodoo_gen ~voodoo_do
              OpamPackage.Map.find (Package.opam package) blessed
              |> Current.map (fun b -> Package.Blessing.Set.get b package)
            in
-           Compile.v ~config ~name ~voodoo:voodoo_do ~blessing ~deps:compile_dependencies prep
+           Compile.v ~generation ~config ~name ~voodoo:voodoo_do ~blessing
+             ~deps:compile_dependencies prep
       in
       compilation_jobs := Package.Map.add package job !compilation_jobs;
       job


### PR DESCRIPTION
By reducing the number of `run` operations, we reduce the number of cache layers. 
Each intermediate layer cost ~7 seconds so for fast commands we're loosing a lot of time for nothing.  