### PR TITLE
Error path

### DIFF
--- a/src/lib/compile.ml
+++ b/src/lib/compile.ml
@@ -190,7 +190,8 @@ module Compile = struct
 
   let obtain_opam_file ~opam_repository ~job package =
     Current_git.with_checkout ~job opam_repository @@ fun dir ->
-    Fpath.(dir / OpamPackage.name_to_string package / OpamPackage.to_string package / "opam")
+    Fpath.(
+      dir / "packages" / OpamPackage.name_to_string package / OpamPackage.to_string package / "opam")
     |> Bos.OS.File.read |> Lwt.return
 
   let build { generation; opam_repository } job Key.{ deps; prep; blessing; voodoo; config } =

--- a/src/lib/compile.mli
+++ b/src/lib/compile.mli
@@ -22,6 +22,7 @@ val package : t -> Package.t
 
 val v :
   generation:Epoch.t Current.t ->
+  opam_repository:Current_git.Commit.t Current.t ->
   config:Config.t ->
   name:string ->
   voodoo:Voodoo.Do.t Current.t ->

--- a/src/lib/opam_metadata.mli
+++ b/src/lib/opam_metadata.mli
@@ -1,0 +1,2 @@
+val v :
+  ssh:Config.Ssh.t -> generation:Epoch.t Current.t -> repo:Current_git.Commit.t Current.t -> string Current.t

--- a/src/lib/pages.ml
+++ b/src/lib/pages.ml
@@ -1,7 +1,5 @@
 (* Pages - /packages/index.html and packages/<foo>/index.html *)
 
-let id = "pages"
-
 let spec ~ssh ~generation ~base ~voodoo ~input_hash () =
   let open Obuilder_spec in
   let tools = Voodoo.Gen.spec ~base voodoo |> Spec.finish in

--- a/src/lib/pages.mli
+++ b/src/lib/pages.mli
@@ -1,0 +1,6 @@
+val v :
+  config:Config.t ->
+  generation:Epoch.t Current.t ->
+  voodoo:Voodoo.Gen.t Current.t ->
+  metadata_branch:string Current.t ->
+  string Current.t

--- a/src/lib/prep.ml
+++ b/src/lib/prep.ml
@@ -201,15 +201,17 @@ end
 
 module PrepCache = Current_cache.Make (Prep)
 
-type t = { hash : string; package : Package.t }
+type prep_result = Success | Failed
+
+type t = { hash : string; package : Package.t; result : prep_result }
 
 let hash t = t.hash
 
 let package t = t.package
 
-type prep_result = [ `Success of t | `Failed of t ]
+let result t = t.result
 
-type prep = prep_result Package.Map.t
+type prep = t Package.Map.t
 
 let pp f t = Fmt.pf f "%s:%s" (Package.id t.package) t.hash
 
@@ -232,8 +234,8 @@ let combine ~(job : Jobs.t) (artifacts_branches_output, failed_branches) =
          let package_id = Package.id package in
          match StringMap.find_opt package_id artifacts_branches_output with
          | Some hash when StringSet.mem package_id failed_branches ->
-             Some (package, `Failed { package; hash })
-         | Some hash -> Some (package, `Success { package; hash })
+             Some (package, { package; hash; result = Failed })
+         | Some hash -> Some (package, { package; hash; result = Success })
          | None -> None)
   |> Package.Map.of_seq
 

--- a/src/lib/prep.mli
+++ b/src/lib/prep.mli
@@ -5,11 +5,13 @@ val hash : t -> string
 
 val package : t -> Package.t
 
-type prep_result = [`Success of t | `Failed of t]
+type prep_result = Success | Failed
+
+val result : t -> prep_result
 
 type prep
 
-val extract : job:Jobs.t -> prep Current.t -> prep_result Current.t Package.Map.t
+val extract : job:Jobs.t -> prep Current.t -> t Current.t Package.Map.t
 
 val v : config:Config.t -> voodoo:Voodoo.Prep.t Current.t -> Jobs.t -> prep Current.t
 (** Install a package universe, extract useful files and push obtained universes on git. *)


### PR DESCRIPTION
Ocurrent-wise, it generates the same graph pipeline. 
But now instead of failing if a package doesn't install, it still runs the compile step using another sequence of instructions. 

It uses an hypothetical `voodoo-do --failed` command. 


Issues: when a package B depends on a failed package A, the compilation of the failure page of B depends on the compilation of the failure page of A, even if there isn't any data dependency. Technically it should be possible to build A and B at the same time but I haven't thought on how to encode that in the ocurrent graph. 