### PR TITLE
unpin odoc-parser

### DIFF
--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -170,9 +170,6 @@ module Do = struct
          [
            run ~network "sudo apt-get update && sudo apt-get install -yy m4";
            run ~network ~cache
-             "opam pin -ny odoc-parser https://github.com/ocaml-doc/odoc-parser.git && opam depext \
-              -iy odoc-parser";
-           run ~network ~cache
              "opam pin -ny odoc %s && opam depext -iy odoc &&  opam exec -- odoc --version"
              (Config.odoc t.config);
            run ~network ~cache "opam pin -ny %s  && opam depext -iy voodoo-do" (remote_uri t.commit);
@@ -199,9 +196,6 @@ module Gen = struct
            run ~network
              "sudo apt-get update && sudo apt-get install -yy m4 && opam repo set-url default \
               https://github.com/ocaml/opam-repository.git#53f602dc16f725d46da26144f29a6be8dfa3c24b";
-           run ~network ~cache
-             "opam pin -ny odoc-parser https://github.com/ocaml-doc/odoc-parser.git && opam depext \
-              -iy odoc-parser";
            run ~network ~cache
              "opam pin -ny odoc %s && opam depext -iy odoc &&  opam exec -- odoc --version"
              (Config.odoc t.config);


### PR DESCRIPTION
This was temporarily used before the package was integrated into opam-repository. Now it's breaking things as `odoc-parser` has unreleased changes in the repository.

This doesn't change any ocurrent hash so we can just re-launch failed jobs.