### PR TITLE
add login

### DIFF
--- a/src/ocaml_docs_ci.ml
+++ b/src/ocaml_docs_ci.ml
@@ -6,7 +6,18 @@ let hourly = Current_cache.Schedule.v ~valid_for:(Duration.of_hour 1) ()
 
 let program_name = "ocaml-docs-ci"
 
-let main current_config mode config =
+(* Access control policy. *)
+let has_role user = function
+  | `Viewer | `Monitor -> true
+  | _ -> (
+      match Option.map Current_web.User.id user with
+      | Some
+          ( "github:talex5" | "github:avsm" | "github:kit-ty-kate" | "github:samoht"
+          | "github:tmcgilchrist" | "github:dra27" | "github:jonludlam" | "github:TheLortex" ) ->
+          true
+      | _ -> false )
+
+let main current_config github_auth mode config =
   let () =
     match Docs_ci_lib.Init.setup (Docs_ci_lib.Config.ssh config) with
     | Ok () -> ()
@@ -19,9 +30,14 @@ let main current_config mode config =
     Current.Engine.create ~config:current_config (fun () ->
         Docs_ci_pipelines.Docs.v ~config ~opam:repo_opam () |> Current.ignore_value)
   in
+  let has_role = if github_auth = None then Current_web.Site.allow_all else has_role in
+  let secure_cookies = github_auth <> None in
   let site =
-    let routes = Current_web.routes engine in
-    Current_web.Site.(v ~has_role:allow_all) ~name:program_name routes
+    let routes =
+      Routes.((s "login" /? nil) @--> Current_github.Auth.login github_auth)
+      :: Current_web.routes engine
+    in
+    Current_web.Site.(v ~has_role ~secure_cookies) ~name:program_name routes
   in
   Logging.run
     (Lwt.choose
@@ -39,7 +55,7 @@ open Cmdliner
 let cmd =
   let doc = "an OCurrent pipeline" in
   ( Term.(
-      const main $ Current.Config.cmdliner $ Current_web.cmdliner
+      const main $ Current.Config.cmdliner $ Current_github.Auth.cmdliner $ Current_web.cmdliner
       $ Docs_ci_lib.Config.cmdliner),
     Term.info program_name ~doc )
 


### PR DESCRIPTION
We need to configure oauth login because random people have started to add random rules in https://docs.ci.ocaml.org/log-rules

Start the service with --github-oauth path.json, where the file contains:

{ "client_id": "...", "client_secret": "...", "scopes": [ "user:email" ] }