### PR TITLE
Prevent rsync from mutating permissions

### DIFF
--- a/src/lib/prep.ml
+++ b/src/lib/prep.ml
@@ -119,7 +119,7 @@ let spec ~ssh ~voodoo ~base ~(install : Package.t) (prep : Package.t list) =
                 create_dir_and_copy_logs_if_not_exist;
                 (* Extract *)
                 Storage.for_all prep_storage_folders
-                  (Fmt.str "rsync -aR ./$1 %s:%s/.;" (Config.Ssh.host ssh)
+                  (Fmt.str "rsync -aR --no-p ./$1 %s:%s/.;" (Config.Ssh.host ssh)
                      (Config.Ssh.storage_folder ssh));
                 (* Compute hashes *)
                 Storage.for_all prep_storage_folders (Storage.Tar.hash_command ~prefix:"HASHES" ());


### PR DESCRIPTION
Fixes an issue where the root of the data storage folder become non-world-readable after a prep step. 
This causes the html frontend to become unavailable (return 403s).

The fix is to make rsync not synchronize permissions.