### PR TITLE
Login fix, odoc 2.0.0 and patch for 4.13

### DIFF
--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -168,7 +168,8 @@ let v cap_file jobs track_packages take_n_last_versions ssh =
 let cmdliner =
   Term.(const v $ cap_file $ jobs $ track_packages $ take_n_last_versions $ Ssh.cmdliner)
 
-let odoc _ = "https://github.com/ocaml/odoc.git#244b5317d05eaa2815f8f5bd0fbc23e9caafd129"
+(* odoc pinned to tag 2.0.0*)
+let odoc _ = "https://github.com/ocaml/odoc.git#34ef06a986a291c8338e62f8de517a1d7ed63e0a"
 
 let pool _ = "linux-x86_64"
 

--- a/src/lib/misc.ml
+++ b/src/lib/misc.ml
@@ -1,3 +1,9 @@
+(* docker manifest inspect ocaml/opam:ubuntu-ocaml-4.13
+
+amd64: sha256:c2278d6ff88b3fc701a04f57231c95f78f0cc38dd2541f90f99e2cb15e96a0aa
+*)
+let ocaml_413_image_hash = "sha256:c2278d6ff88b3fc701a04f57231c95f78f0cc38dd2541f90f99e2cb15e96a0aa"
+
 let base_image_version package =
   let deps = Package.all_deps package in
   let ocaml_version =
@@ -5,16 +11,17 @@ let base_image_version package =
     |> List.find_opt (fun pkg ->
            pkg |> Package.opam |> OpamPackage.name_to_string = "ocaml-base-compiler")
     |> Option.map (fun pkg -> pkg |> Package.opam |> OpamPackage.version_to_string)
-    |> Option.value ~default:"4.12.0"
+    |> Option.value ~default:"4.13.0"
   in
   match Astring.String.cuts ~sep:"." ocaml_version with
+  | [ "4"; "13"; _micro ] -> "4.13@" ^ ocaml_413_image_hash
   | [ major; minor; _micro ] -> major ^ "." ^ minor
-  | _xs -> "4.12"
+  | _xs -> "4.13@" ^ ocaml_413_image_hash
 
 (** Select base image to use *)
 let get_base_image package = Spec.make ("ocaml/opam:ubuntu-ocaml-" ^ base_image_version package)
 
-let default_base_image = Spec.make "ocaml/opam:ubuntu-ocaml-4.12"
+let default_base_image = Spec.make ("ocaml/opam:ubuntu-ocaml-4.13@" ^ ocaml_413_image_hash)
 
 let network = [ "host" ]
 

--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -195,7 +195,7 @@ module Gen = struct
          [
            run ~network
              "sudo apt-get update && sudo apt-get install -yy m4 && opam repo set-url default \
-              https://github.com/ocaml/opam-repository.git#53f602dc16f725d46da26144f29a6be8dfa3c24b";
+              https://github.com/ocaml/opam-repository.git#c1ab98721ec2efc4c65d0c5a65a85c826925db6c";
            run ~network ~cache
              "opam pin -ny odoc %s && opam depext -iy odoc &&  opam exec -- odoc --version"
              (Config.odoc t.config);
@@ -208,3 +208,4 @@ module Gen = struct
 
   let commit t = t.commit
 end
+

--- a/src/ocaml_docs_ci.ml
+++ b/src/ocaml_docs_ci.ml
@@ -32,12 +32,13 @@ let main current_config github_auth mode config =
   in
   let has_role = if github_auth = None then Current_web.Site.allow_all else has_role in
   let secure_cookies = github_auth <> None in
+  let authn = Option.map Current_github.Auth.make_login_uri github_auth in
   let site =
     let routes =
       Routes.((s "login" /? nil) @--> Current_github.Auth.login github_auth)
       :: Current_web.routes engine
     in
-    Current_web.Site.(v ~has_role ~secure_cookies) ~name:program_name routes
+    Current_web.Site.(v ?authn ~has_role ~secure_cookies) ~name:program_name routes
   in
   Logging.run
     (Lwt.choose


### PR DESCRIPTION
Currently there are `4.13.0+trunk` compiler images in some worker's cache. This break our builds because that version disappeared later in from the opam repository, resulting in resolution failures. So we force the usage of a more recent recent of the base image.

Oh, and let's switch to odoc 2.0.0 ! :tada: 

Login fix: this is something in `live` that I forgot to put on the main branch