### PR TITLE
Possible evil workaround to git URL deprecation

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/TheLortex/ocluster
 [submodule "vendor/ocurrent"]
 	path = vendor/ocurrent
-	url = https://github.com/TheLortex/ocurrent
+	url = https://github.com/dra27/ocurrent

--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -116,9 +116,9 @@ let v config =
   { voodoo_do; voodoo_prep; voodoo_gen; config }
 
 let remote_uri commit =
-  let repo = Git.Commit_id.repo commit in
+  (*let repo = Git.Commit_id.repo commit in*)
   let commit = Git.Commit_id.hash commit in
-  repo ^ "#" ^ commit
+  "https://github.com/ocaml-doc/voodoo.git#" ^ commit
 
 let digest t =
   let key =


### PR DESCRIPTION
Possible investigation to [this kind of failure](https://docs.ci.ocaml.org/job/2022-03-30/141437-voodoo-prep-5e78e8) for now. In this instance, the [clone stage](https://docs.ci.ocaml.org/job/2022-03-30/141242-git-clone-ead2a3) is returning the correct repo thanks to #72 which is why some prep jobs have unblocked (previously, trying to clone that repo would have broken them all).

However, if I read it correctly, the caching on the [voodoo stage](https://docs.ci.ocaml.org/job/2022-02-12/015054-voodoo-repository-d9be7b) is keyed on the commit sha only and includes the repo as the value. So if the clone is returning the same commit as before (which it will be), then we're going to try to fetch from git://github.com instead of https://github.com.

Investigating this with a little hack here...