### PR TITLE
Backport @TheLortex upper bound fix and unify deps

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -22,6 +22,7 @@
    (>= 4.11.0))
   (current
    (>= 0.3))
+  (cstruct (< 6.1.0))
   current_web
   current_git
   current_github

--- a/ocaml-docs-ci.opam
+++ b/ocaml-docs-ci.opam
@@ -10,6 +10,7 @@ depends: [
   "dune" {>= "2.8"}
   "ocaml" {>= "4.11.0"}
   "current" {>= "0.3"}
+  "cstruct" {< "6.1.0"}
   "current_web"
   "current_git"
   "current_github"

--- a/src/lib/misc.ml
+++ b/src/lib/misc.ml
@@ -82,15 +82,10 @@ module Peeker = Current_cache.Make(PeekerBody)
 module Image : sig
   val peek : Ocaml_version.t -> string Current.t
 end = struct
-  let images = ref []
   let weekly = Current_cache.Schedule.v ~valid_for:(Duration.of_day 7) ()
   let real_peek ocaml_version =
-    try List.assoc ocaml_version !images
-    with Not_found ->
-      (* let* _ = Current_docker.Default.pull ~schedule:weekly ~arch tag in *)
-      let output = Peeker.get ~schedule:weekly () ocaml_version in
-      images := (ocaml_version, output) :: !images;
-      output
+    (* let* _ = Current_docker.Default.pull ~schedule:weekly ~arch tag in *)
+    Peeker.get ~schedule:weekly () ocaml_version
 
   let peek ocaml_version =
     let tag = tag ocaml_version in


### PR DESCRIPTION
This PR intends to conform the `main` branch with the fix from `live`. As a result, we will be able to use again `master` as the main branch and `live` as a production branch. The changes are:
- Use the right version for `cstruct`
- Remove this infinite loop that occurred with `Peeker.get` and `try ... with`