### PR TITLE
Add a monitoring page for the ci status

### DIFF
--- a/src/lib/monitor.ml
+++ b/src/lib/monitor.ml
@@ -55,9 +55,7 @@ let rec render ~level =
   let open Tyxml_html in
   function
   | Item current ->
-    let result = 
-      Current.observe current 
-    in
+    let result = Current.observe current in
     let container =
       try 
         Current.Analysis.metadata current
@@ -162,7 +160,7 @@ let rec pipeline_state = function
     (match result with
     | Ok _ -> Done
     | Error (`Active _) -> Running
-    | Error `Blocked -> Failed
+    | Error `Blocked -> Running
     | Error (`Msg _) -> Failed)
   | Seq lst | And lst | Or lst -> 
     List.fold_left 

--- a/src/lib/monitor.ml
+++ b/src/lib/monitor.ml
@@ -151,6 +151,8 @@ let handle t ~engine:_ str =
   object
     inherit Current_web.Resource.t
 
+    val! can_get = `Viewer
+
     method! private get context =
       let response = 
         match render_package_state t str with

--- a/src/lib/monitor.ml
+++ b/src/lib/monitor.ml
@@ -1,0 +1,207 @@
+
+type pipeline_tree =
+  | Item : 'a Current.t -> pipeline_tree
+  | Seq of (string * pipeline_tree) list
+  | And of (string * pipeline_tree) list 
+
+type t = {
+  mutable blessing: Package.Blessing.Set.t Current.t OpamPackage.Map.t;
+  mutable trees:  pipeline_tree Package.Map.t 
+}
+
+let make () = {
+  blessing=OpamPackage.Map.empty;
+  trees=Package.Map.empty;
+}
+
+let register t blessing trees =
+  t.blessing <- blessing;
+  t.trees <- trees
+
+let (let*) = Result.bind
+let (let+) a f = Result.map f a
+
+let rec simplify = 
+  function
+  | And [(_, a)] -> simplify a
+  | v -> v 
+
+let render_level = 
+  let open Tyxml_html in
+  function
+  | 0 -> h1
+  | 1 -> h2
+  | 2 -> h3
+  | 3 -> h4
+  | 4 -> h5
+  | _ -> h6
+
+let render_list ~bullet ~level ~items ~render =
+  let open Tyxml_html in
+  ul(
+    List.map (fun (name, item) -> 
+      li ~a:[a_style ("list-style-type: " ^ bullet)]  [
+      (render_level level) [ txt name ];
+      render ~level:(level+1) item
+    ]) items)
+
+let rec render ~level = 
+  let open Tyxml_html in
+  function
+  | Item current ->
+    let result = 
+      Current.observe current 
+    in
+    let container =
+      try 
+        Current.Analysis.metadata current
+        |> Current.observe
+        |> Result.to_option
+        |> Option.join
+        |> function
+        | Some {job_id = Some job_id; _} -> 
+          fun v -> a ~a:[a_href ("/job/" ^ job_id)] [txt v]
+        | _ -> txt
+      with (* if current is not a primitive term *)
+      Failure _ -> txt
+    in
+    begin
+    match result with
+    | Error (`Msg  msg) -> container ("error: " ^ msg)
+    | Error (`Active _) -> container "active"
+    | Error `Blocked -> container "blocked"
+    | Ok _ -> container "OK"
+    end
+  | Seq items -> 
+    render_list ~bullet:"decimal" ~level ~items ~render
+  | And items -> 
+    render_list ~bullet:"circle" ~level ~items ~render
+
+let get_package_info t name =
+  let* opam_package = 
+    OpamPackage.of_string_opt name 
+    |> Option.to_result ~none:"invalid package name"
+  in
+  let* blessing_current =
+    OpamPackage.Map.find_opt opam_package t.blessing
+    |> Option.to_result ~none:"couldn't find package"
+  in
+  let+ blessing_set = 
+    Current.observe blessing_current
+    |> function
+    | Ok v -> Ok v
+    | Error _ -> Error "couldn't find blessing set"
+  in
+  let blessed_package = 
+    Package.Blessing.Set.blessed blessing_set 
+  in
+  let blessed_pipeline =
+    Package.Map.find blessed_package t.trees
+  in
+  blessed_package, blessed_pipeline
+
+
+let render_package_state t name =
+  let* (_, blessed_pipeline) = get_package_info t name
+  in
+  let open Tyxml_html in
+  Ok
+  [
+    h1 [txt ("Package " ^ name)];
+    (render ~level:1 (simplify blessed_pipeline))
+  ]
+
+let handle t ~engine:_ str =
+  object
+    inherit Current_web.Resource.t
+
+    method! private get context =
+      let response = 
+        match render_package_state t str with
+        | Ok page -> page
+        | Error msg -> Tyxml_html.[
+            txt ("An error occured:");
+            br ();  
+            i [
+              txt msg
+            ]
+          ]
+      in
+      Current_web.Context.respond_ok context response
+
+  end
+
+type state = Done | Running | Failed
+
+let max a b = match (a,b) with
+  | Done, v -> v
+  | v, Done -> v
+  | _, Failed -> Failed
+  | Failed, _ -> Failed
+  | Running, Running -> Running
+
+let rec pipeline_state = function
+  | Item v ->
+    let result = Current.observe v
+    in
+    (match result with
+    | Ok _ -> Done
+    | Error (`Active _) -> Running
+    | Error `Blocked -> Failed
+    | Error (`Msg _) -> Failed)
+  | Seq lst | And lst -> 
+    List.fold_left 
+      (fun acc (_, v) -> max (pipeline_state v) acc) 
+      Done 
+      lst
+
+let opam_package_state t name =
+  match 
+    let+ (_, blessed_pipeline) = get_package_info t name
+    in pipeline_state blessed_pipeline
+  with
+  | Ok v -> v
+  | _ -> Failed
+
+let render_link (pkg, _) =
+  let open Tyxml_html in
+  let name = OpamPackage.to_string pkg in
+  li [
+    a ~a:[a_href ("/package/"^name)] [
+      txt name
+    ]
+  ]
+
+let render_package_root t =
+  let failed, pending =
+    OpamPackage.Map.keys t.blessing
+    |> List.map (fun k -> k, opam_package_state t (OpamPackage.to_string k))
+    |> List.filter (fun (_, st) -> st != Done)
+    |> List.partition (fun (_, st) -> st == Failed)
+  in
+  let open Tyxml_html in
+  [
+    h1 [txt "Failed packages"];
+    ul (List.map render_link failed);
+    h1 [txt "Running packages"];
+    ul (List.map render_link pending);
+  ]
+
+let handle_root t ~engine:_ =
+  object
+    inherit Current_web.Resource.t
+    method! nav_link = Some "Packages"
+
+    method! private get context =
+      let response = render_package_root t
+      in
+      Current_web.Context.respond_ok context response
+
+  end
+      
+let routes t engine =
+  Routes.
+    [
+      (s "package" / str /? nil) @--> handle t ~engine;
+      (s "package" /? nil) @--> handle_root t ~engine;
+    ]

--- a/src/lib/monitor.ml
+++ b/src/lib/monitor.ml
@@ -205,6 +205,8 @@ let handle_root t ~engine:_ =
     inherit Current_web.Resource.t
     method! nav_link = Some "Packages"
 
+    val! can_get = `Viewer
+
     method! private get context =
       let response = render_package_root t
       in

--- a/src/lib/monitor.mli
+++ b/src/lib/monitor.mli
@@ -1,0 +1,22 @@
+type t
+(** The type for the ci monitor*)
+
+val make : unit -> t
+(** Create a monitor *)
+
+type pipeline_tree =
+  | Item : 'a Current.t -> pipeline_tree
+  | Seq of (string * pipeline_tree) list
+  | And of (string * pipeline_tree) list 
+(** The pipeline dependency tree to produces artifacts for
+    a given package. *)
+
+val register : 
+  t -> 
+  Package.Blessing.Set.t Current.t OpamPackage.Map.t -> 
+  pipeline_tree Package.Map.t -> unit
+(** Register Current.t values for each package in the CI system. *)
+
+val routes : 
+  t -> Current.Engine.t -> Current_web.Resource.t Routes.route list
+(** Routes for the renderer *)

--- a/src/lib/monitor.mli
+++ b/src/lib/monitor.mli
@@ -8,15 +8,17 @@ type pipeline_tree =
   | Item : 'a Current.t -> pipeline_tree
   | Seq of (string * pipeline_tree) list
   | And of (string * pipeline_tree) list 
+  | Or of (string * pipeline_tree) list 
 (** The pipeline dependency tree to produces artifacts for
     a given package. *)
 
-val register : 
-  t -> 
-  Package.Blessing.Set.t Current.t OpamPackage.Map.t -> 
+val register :
+  t ->
+  (Package.t * _ Current.t) list OpamPackage.Map.t ->
+  Package.Blessing.Set.t Current.t OpamPackage.Map.t ->
   pipeline_tree Package.Map.t -> unit
 (** Register Current.t values for each package in the CI system. *)
 
-val routes : 
+val routes :
   t -> Current.Engine.t -> Current_web.Resource.t Routes.route list
 (** Routes for the renderer *)

--- a/src/lib/monitor.mli
+++ b/src/lib/monitor.mli
@@ -14,6 +14,7 @@ type pipeline_tree =
 
 val register :
   t ->
+  (OpamPackage.t * string) list ->
   (Package.t * _ Current.t) list OpamPackage.Map.t ->
   Package.Blessing.Set.t Current.t OpamPackage.Map.t ->
   pipeline_tree Package.Map.t -> unit

--- a/src/lib/package.ml
+++ b/src/lib/package.ml
@@ -151,10 +151,7 @@ module Blessing = struct
       assert (Package.opam pkg = opam);
       of_bool (Universe.hash (Package.universe pkg) = universe)
     
-    let blessed t = 
-      match t.blessed with
-      | None -> failwith "Blessed package set is empty"
-      | Some v -> v
+    let blessed t = t.blessed
   end
 end
 

--- a/src/lib/package.mli
+++ b/src/lib/package.mli
@@ -61,5 +61,9 @@ module Blessing : sig
     (** Compute which packages are blessed. *)
 
     val get : t -> Package.t -> b
+    
+    val blessed : t -> Package.t
+    (** Obtain which package is blessed, 
+        or raise if the set is empty *)
   end
 end

--- a/src/lib/package.mli
+++ b/src/lib/package.mli
@@ -62,7 +62,7 @@ module Blessing : sig
 
     val get : t -> Package.t -> b
     
-    val blessed : t -> Package.t
+    val blessed : t -> Package.t option
     (** Obtain which package is blessed, 
         or raise if the set is empty *)
   end

--- a/src/lib/prep.ml
+++ b/src/lib/prep.ml
@@ -92,6 +92,7 @@ let spec ~ssh ~voodoo ~base ~(install : Package.t) (prep : Package.t list) =
          run "sudo mkdir /src";
          copy [ "packages" ] ~dst:"/src/packages";
          copy [ "repo" ] ~dst:"/src/repo";
+         run "sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && opam update";
          run "opam repo remove default && opam repo add opam /src";
          copy ~from:(`Build "tools") [ "/home/opam/voodoo-prep" ] ~dst:"/home/opam/";
          (* Pre-install build tools *)

--- a/src/lib/prep.ml
+++ b/src/lib/prep.ml
@@ -239,7 +239,9 @@ let combine ~base ~(job : Jobs.t) (artifacts_branches_output, failed_branches) =
 let v ~config ~voodoo ~spec (job : Jobs.t) =
   let open Current.Syntax in
   Current.component "voodoo-prep %s" (job.install |> Package.digest)
-  |> let> voodoo = voodoo in
+  |> let> voodoo = voodoo 
+     and> spec = spec 
+     in
      PrepCache.get No_context { job; voodoo; config; base = spec }
      |> Current.Primitive.map_result (Result.map (combine ~base:spec ~job))
 

--- a/src/lib/prep.mli
+++ b/src/lib/prep.mli
@@ -13,7 +13,8 @@ type prep
 
 val extract : job:Jobs.t -> prep Current.t -> t Current.t Package.Map.t
 
-val v : config:Config.t -> voodoo:Voodoo.Prep.t Current.t -> spec:Spec.t -> Jobs.t -> prep Current.t
+val v : config:Config.t -> voodoo:Voodoo.Prep.t Current.t -> 
+        spec:Spec.t Current.t -> Jobs.t -> prep Current.t
 (** Install a package universe, extract useful files and push obtained universes on git. *)
 
 val pp : t Fmt.t

--- a/src/lib/solver.ml
+++ b/src/lib/solver.ml
@@ -141,7 +141,7 @@ module Cache = struct
       let result = Marshal.from_channel file in
       close_in file;
       Some result
-    with Failure _ ->
+    with Failure _ | Sys_error _ ->
     match V1.read track with
     | None -> None
     | Some v ->

--- a/src/lib/solver.mli
+++ b/src/lib/solver.mli
@@ -4,6 +4,7 @@ type t
 type key
 
 val keys : t -> key list
+val failures : t -> (OpamPackage.t * string) list
 val get : key -> Package.t
 
 val incremental :

--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -183,8 +183,7 @@ module Gen = struct
     |> Spec.add
          [
            run ~network
-             "sudo apt-get update && sudo apt-get install -yy m4 && opam repo set-url default \
-              https://github.com/ocaml/opam-repository.git#c1ab98721ec2efc4c65d0c5a65a85c826925db6c";
+             "sudo apt-get update && sudo apt-get install -yy m4";
            run ~network ~cache
              "opam pin -ny odoc %s && opam depext -iy odoc &&  opam exec -- odoc --version"
              (Config.odoc t.config);

--- a/src/pipelines/docs.ml
+++ b/src/pipelines/docs.ml
@@ -271,6 +271,7 @@ let v ~config ~opam ~monitor () =
     let compile_monitor =
       compile ~generation ~config ~voodoo_do:v_do ~voodoo_gen:v_gen ~blessed prepped'
     in
+    Log.info (fun f -> f ".. %d compilation nodes" (List.length compile_monitor));
     let c, compile_node =
       compile_monitor
       |> List.map (fun (a, (b, _)) -> (a,b))

--- a/src/pipelines/docs.ml
+++ b/src/pipelines/docs.ml
@@ -282,7 +282,7 @@ let v ~config ~opam ~monitor () =
     |> List.map (fun (a, (_, b)) -> (a,b))
     |> List.to_seq |> Package.Map.of_seq)
   in
-
+  Log.info (fun f -> f "7) Odoc compile nodes");
   (* 7.b) Inform the monitor *)
 
   let () =
@@ -291,7 +291,7 @@ let v ~config ~opam ~monitor () =
     Monitor.register monitor 
       solver_failures prep_nodes blessed package_pipeline_tree
   in
-  Log.info (fun f -> f "7) Odoc compile nodes");
+  Log.info (fun f -> f "7.b) Inform monitor");
   
   (* 8) Update live folders *)
   let live_branch =

--- a/src/pipelines/docs.ml
+++ b/src/pipelines/docs.ml
@@ -203,9 +203,7 @@ let v ~config ~opam ~monitor () =
   let prepped, prepped_input_node =
     jobs'
     |> List.map (fun (job, spec) ->
-           ( job,
-             let* spec = spec in
-             Prep.v ~config ~voodoo:v_prep ~spec job ))
+           ( job, Prep.v ~config ~voodoo:v_prep ~spec job ))
     |> prep_hierarchical_collapse ~input:solver_result_c
   in
   let prepped' =

--- a/src/pipelines/docs.ml
+++ b/src/pipelines/docs.ml
@@ -61,8 +61,14 @@ let compile ~generation ~config ~voodoo_gen ~voodoo_do
             Seq [
               ("do-deps", And
                 (("prep", Item prep_node) ::
-                List.map (fun (pkg, compile) -> 
-                  ("dep-compile " ^ Package.id pkg, Item compile)) 
+                List.map (fun (pkg, compile) ->
+                  let dep_prep_node, _ =
+                    Package.Map.find pkg preps 
+                  in 
+                  ("dep-compile " ^ Package.id pkg, And [
+                    ("prep", Item dep_prep_node);
+                    ("compile", Item compile)
+                  ])) 
                   compile_dependencies_names)
               );
               ("do-compile", Item node)

--- a/src/pipelines/docs.ml
+++ b/src/pipelines/docs.ml
@@ -213,15 +213,11 @@ let v ~config ~opam ~monitor () =
          Package.Map.empty
   in
   let prep_nodes = 
-    prepped
-    |> List.map (fun (job, result) -> 
-      job.Jobs.prep 
-      |> List.map (fun p -> 
-        OpamPackage.Map.singleton (Package.opam p) [p, result]))
-    |> List.flatten
-    |> List.fold_left
-         (OpamPackage.Map.union ( @ ))
-         OpamPackage.Map.empty
+    Package.Map.fold
+      (fun package (prep_job, _) opam_map ->
+        let opam = Package.opam package in
+        OpamPackage.Map.update opam (List.cons (package, prep_job)) [] opam_map)
+      prepped' OpamPackage.Map.empty
   in
   (* 6) Promote packages to the main tree *)
   let blessed =

--- a/src/pipelines/docs.ml
+++ b/src/pipelines/docs.ml
@@ -200,11 +200,10 @@ let v ~config ~opam ~monitor () =
   let jobs' = jobs |> List.map (fun job -> (job, Misc.spec_of_job job)) in
   Log.info (fun f -> f "4) Jobs are scheduled");
   (* 5) Run the preparation step *)
-  let prepped, prepped_input_node =
+  let prepped =
     jobs'
     |> List.map (fun (job, spec) ->
            ( job, Prep.v ~config ~voodoo:v_prep ~spec job ))
-    |> prep_hierarchical_collapse ~input:solver_result_c
   in
   let prepped' =
     prepped
@@ -273,7 +272,7 @@ let v ~config ~opam ~monitor () =
     let c, compile_node =
       compile_monitor
       |> List.map (fun (a, (b, _)) -> (a,b))
-      |> compile_hierarchical_collapse ~input:prepped_input_node
+      |> compile_hierarchical_collapse ~input:solver_result_c
     in
     (c |> List.to_seq |> Package.Map.of_seq, 
     compile_node,

--- a/src/solver/solver.ml
+++ b/src/solver/solver.ml
@@ -8,7 +8,7 @@ let env (vars : Worker.Vars.t) =
     Opam_0install.Dir_context.std_env ~arch:vars.arch ~os:vars.os
       ~os_distribution:vars.os_distribution ~os_version:vars.os_version ~os_family:vars.os_family ()
   in
-  function "opam-version" -> Some (OpamTypes.S "2.1") | v -> env v
+  function "opam-version" -> Some (OpamTypes.S "2.1.0") | v -> env v
 
 let get_names = OpamFormula.fold_left (fun a (name, _) -> name :: a) []
 

--- a/src/solver/solver.ml
+++ b/src/solver/solver.ml
@@ -8,7 +8,7 @@ let env (vars : Worker.Vars.t) =
     Opam_0install.Dir_context.std_env ~arch:vars.arch ~os:vars.os
       ~os_distribution:vars.os_distribution ~os_version:vars.os_version ~os_family:vars.os_family ()
   in
-  function "opam-version" -> Some (OpamTypes.S "2.0") | v -> env v
+  function "opam-version" -> Some (OpamTypes.S "2.1") | v -> env v
 
 let get_names = OpamFormula.fold_left (fun a (name, _) -> name :: a) []
 

--- a/test/monitor/dune
+++ b/test/monitor/dune
@@ -1,0 +1,3 @@
+(executable
+ (name test_monitor)
+ (libraries docs_ci_lib current current_web cmdliner))

--- a/test/monitor/test_monitor.ml
+++ b/test/monitor/test_monitor.ml
@@ -67,7 +67,7 @@ let pipeline monitor =
     |> List.to_seq
     |> Package.Map.of_seq
   in
-  Monitor.(register monitor blessing values);
+  Monitor.(register monitor OpamPackage.Map.empty blessing values);
 
   Current.all [
     step1 |> Current.map ignore;

--- a/test/monitor/test_monitor.ml
+++ b/test/monitor/test_monitor.ml
@@ -67,7 +67,10 @@ let pipeline monitor =
     |> List.to_seq
     |> Package.Map.of_seq
   in
-  Monitor.(register monitor OpamPackage.Map.empty blessing values);
+  let solve_failure = 
+    [OpamPackage.of_string "mirage.4.0.0", "solver failed"]
+  in
+  Monitor.(register monitor solve_failure OpamPackage.Map.empty blessing values);
 
   Current.all [
     step1 |> Current.map ignore;

--- a/test/monitor/test_monitor.ml
+++ b/test/monitor/test_monitor.ml
@@ -1,0 +1,118 @@
+let step1 = Current_git.clone 
+  ~schedule:(Current_cache.Schedule.v ())
+  ~gref:"main"
+  "https://github.com/ocurrent/ocaml-docs-ci.git"
+
+let step2 = Current_git.clone 
+  ~schedule:(Current_cache.Schedule.v ())
+  "https://google.com/"
+
+let step3: unit Current.t = Current.fail "oh no"
+
+let running = 
+  Current_docker.Default.build ~level:Current.Level.Dangerous
+  ~pull:false
+  `No_context
+
+let fakepkg ~blessing name =
+  let open Docs_ci_lib in
+  let root = OpamPackage.of_string name in
+  let pkg = Package.make 
+    ~blacklist:[]
+    ~commit:"0"
+    ~root
+    []
+  in
+  let blessing =
+    let set = 
+      Package.Blessing.Set.v
+        ~counts:(Package.Map.singleton pkg 0)
+        [pkg]
+    in
+    OpamPackage.Map.add
+      root
+      (Current.return set)
+      blessing
+  in
+  pkg, blessing
+
+
+let pipeline monitor =
+  let open Docs_ci_lib in
+  let blessing = OpamPackage.Map.empty in
+  let pkg, blessing = fakepkg ~blessing "docs-ci.1.0.0" in
+  let pkg2, blessing = fakepkg ~blessing "ocurrent.1.1.0" in
+  let pkg3, blessing = fakepkg ~blessing "ocluster.0.7.0" in
+
+  let values =
+    [pkg, Monitor.(
+      Seq [
+        ("step1", Item step1);
+        ("step2", Item step2);
+        ("and-pattern", And [
+          ("sub-step3", Item step1);
+          ("sub-step4", Item step3);
+        ])
+      ]
+    );
+    pkg2, Monitor.(
+      Seq [
+        ("fake running step", Item running);
+      ]
+    );
+    pkg3, Monitor.(
+      Item step1
+    )
+    ]
+    |> List.to_seq
+    |> Package.Map.of_seq
+  in
+  Monitor.(register monitor blessing values);
+
+  Current.all [
+    step1 |> Current.map ignore;
+    step2 |> Current.map ignore;
+    step3 |> Current.map ignore;
+    running |> Current.map ignore;
+  ]
+
+let () =
+  Fmt_tty.setup_std_outputs ();
+  Logs.set_level (Some Debug);
+  Logs.set_reporter (Logs_fmt.reporter ())
+
+let main mode =
+  let monitor = Docs_ci_lib.Monitor.make () in
+  let engine =
+    Current.Engine.create 
+      ~config:(Current.Config.v ~confirm:Current.Level.Average ()) 
+      (fun () -> pipeline monitor)
+  in
+  let has_role = Current_web.Site.allow_all in
+  let site =
+    let routes =
+      Current_web.routes engine
+      @ Docs_ci_lib.Monitor.routes monitor engine
+    in
+    Current_web.Site.(v ~has_role) ~name:"test_monitor" routes
+  in
+  ignore @@
+  Lwt_main.run
+    (Lwt.choose
+       [
+         Current.Engine.thread engine;
+         (* The main thread evaluating the pipeline. *)
+         Current_web.run ~mode site (* Optional: provides a web UI *);
+       ])
+
+(* Command-line parsing *)
+
+open Cmdliner
+
+let cmd =
+  let info = Cmd.info "test_monitor" in
+  Cmd.v info 
+    Term.( const main $ Current_web.cmdliner)
+
+let () = exit @@ Cmd.eval cmd
+       


### PR DESCRIPTION
Currently it's hard to figure out why packages fail. One can randomly look at failures but it is not efficient.

This PR adds a current web page to display which packages are not displayed on the documentation website and gives an overview of at which stage it went wrong. 

![Screenshot 2022-08-26 at 17-43-13 test_monitor](https://user-images.githubusercontent.com/966015/186943503-71145551-2fc4-4e59-9017-c83e16c78e85.png)

![Screenshot 2022-08-26 at 17-43-24 test_monitor](https://user-images.githubusercontent.com/966015/186943531-9aa037d0-620c-4de9-839f-dc448b593bf8.png)

I have also added a minimal example using the monitor module to test its behaviour.


## warning

I needed to expose ocurrent's executor module to obtain this feature.
```
module Executor : sig
    val run : 'a Current.t -> 'a Output.t Current_incr.t
end
```

The rationale is that I don't want to maintain the monitor's state using ocurrent because it would require tracking a lot of nodes. Instead it's better to query the ocurrent state occasionally (when the page is requested) using this function. 
It's done in this commit: https://github.com/TheLortex/ocurrent/commit/c9f5f9a882d02426937988dccdd7ba291185be29
@talex5 what do you think ? it's low level but would it be possible to have that somewhere in the ocurrent api ?

 