### PR TITLE
Add opam pins to the Makefile, mention git submodules to build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,14 @@ all:
 
 .PHONY: deps
 deps: ## Install development dependencies
-	opam install -y dune-release ocamlformat utop ocaml-lsp-server
+	opam pin add -yn current_docker.dev "./vendor/ocurrent" && \
+	opam pin add -yn current_github.dev "./vendor/ocurrent" && \
+	opam pin add -yn current_git.dev "./vendor/ocurrent" && \
+	opam pin add -yn current.dev "./vendor/ocurrent" && \
+	opam pin add -yn current_rpc.dev "./vendor/ocurrent" && \
+	opam pin add -yn current_slack.dev "./vendor/ocurrent" && \
+	opam pin add -yn current_web.dev "./vendor/ocurrent"
+	opam install -y dune-release ocamlformat utop ocaml-lsp-server obuilder-spec
 	opam install --deps-only --with-test --with-doc -y .
 
 .PHONY: create_switch

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Building docs using odoc.
 
+## Before building
+
+`ocurrent`, `ocluster` and `ocluster/obuilder` are included as git submodules. Make sure they are checked out:
+
+```
+git submodule update --init --recursive
+```
+
 ## Running
 
 ```


### PR DESCRIPTION
Adds the opam pins from the Dockerfile to the Makefile, remind to check out git submodules before building locally.