### PR TITLE
observe live branch of voodoo instead of main

### DIFF
--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -97,7 +97,7 @@ module VoodooCache = Current_cache.Make (Op)
 
 let v () =
   let daily = Current_cache.Schedule.v ~valid_for:(Duration.of_day 1) () in
-  let git = Git.clone ~schedule:daily ~gref:"main" "https://github.com/ocaml-doc/voodoo.git" in
+  let git = Git.clone ~schedule:daily ~gref:"live" "https://github.com/ocaml-doc/voodoo.git" in
   let open Current.Syntax in
   Current.component "voodoo"
   |> let> git = git in


### PR DESCRIPTION
To make updates to voodoo more explicit, the pipeline now listens to the new `live` branch of `voodoo`, instead of the `main` branch.

Then, we can merge multiple PRs on `voodoo`'s `main` branch, and, after we are sure we want to deploy this, update the `live` branch. This makes sure we only trigger new builds when we actually intend to.