### PR TITLE
upgrade to odoc 2.2.0

### DIFF
--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -164,8 +164,8 @@ let v cap_file jobs track_packages take_n_last_versions ssh =
 let cmdliner =
   Term.(const v $ cap_file $ jobs $ track_packages $ take_n_last_versions $ Ssh.cmdliner)
 
-(* odoc pinned to tag 2.1.1 *)
-let odoc _ = "https://github.com/ocaml/odoc.git#f556f10aa67f80e83d1e3e66c4b478e8efe4e18d"
+(* odoc pinned to tag 2.2.0 *)
+let odoc _ = "https://github.com/ocaml/odoc.git#103dac4c370aa2ad5aca7ba54f02f8e06adb941b"
 let pool _ = "linux-x86_64"
 let jobs t = t.jobs
 let track_packages t = t.track_packages


### PR DESCRIPTION
We upgraded voodoo to odoc 2.2.0, omd 2.2.0alpha~3 and made pandoc a depext of voodoo here: https://github.com/ocaml-doc/voodoo/pull/52

The alpinejs docker probably image needs to be upgraded to one that has pandoc.