### PR TITLE
Export voodoo options on the cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ A [docker-compose.yml](docker-compose.yml) is provided to setup an entire `docs-
  * docs-ci built from the local git checkout
 
 Run this command to create an environment:
+
 ``` shell
 $ docker-compose -f docker-compose.yml up
 ```

--- a/src/lib/config.mli
+++ b/src/lib/config.mli
@@ -24,6 +24,9 @@ val odoc : t -> string
 val pool : t -> string
 (** The ocluster pool to use *)
 
+val voodoo_repo : t -> string
+val voodoo_branch : t -> string
+
 val ocluster_connection_prep : t -> Current_ocluster.Connection.t
 (** Connection to the cluster for Prep *)
 

--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -95,9 +95,9 @@ end
 
 module VoodooCache = Current_cache.Make (Op)
 
-let v () =
+let v ~gref ~repo () =
   let daily = Current_cache.Schedule.v ~valid_for:(Duration.of_day 1) () in
-  let git = Git.clone ~schedule:daily ~gref:"main" "https://github.com/ocaml-doc/voodoo.git" in
+  let git = Git.clone ~schedule:daily ~gref repo in
   let open Current.Syntax in
   Current.component "voodoo"
   |> let> git = git in
@@ -112,7 +112,7 @@ type t = {
 
 let v config =
   let open Current.Syntax in
-  let+ { voodoo_do; voodoo_prep; voodoo_gen } = v () in
+  let+ { voodoo_do; voodoo_prep; voodoo_gen } = v ~gref:(Config.voodoo_branch config) ~repo:(Config.voodoo_repo config) () in
   { voodoo_do; voodoo_prep; voodoo_gen; config }
 
 let remote_uri commit =


### PR DESCRIPTION
This allows for setting the voodoo branch and repo from the cli, enabling better dev and deployment options.