### PR TITLE
Log obuilder spec used for prep stage.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - 'capnp-secrets:/capnp-secrets:ro'
     environment:
       - DOCKER_BUILDKIT=1
+      - DOCKER_CLI_EXPERIMENTAL=enabled
 
   init:
     build:
@@ -111,6 +112,8 @@ services:
       - --ssh-privkey=/ssh/id_ed25519
       - --ssh-pubkey=/ssh/id_ed25519.pub
       - --ssh-folder=/data
+      # - --voodoo-repo=""      # Voodoo repository to use
+      # - --voodoo-branch=""    # Git branch from the voodoo repository
       - --jobs=6
       - --limit=1               # Only build the most recent version of each package
       - --filter=capnp-rpc      # NOTE Only build capnp-rpc documentation.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,14 +18,16 @@ services:
       - 'scheduler-data:/var/lib/ocluster-scheduler'
       - 'capnp-secrets:/capnp-secrets'
 
-  worker:
-    # image: ocurrent/ocluster-worker:live
+  # Single ocluster worker to run builds.
+  # Additional workers can be added by copying this block and giving
+  # the new worker a unique "--name"
+  worker_a:
     build:
       dockerfile: docker/worker/Dockerfile
       context: .
     command:
       - --connect=/capnp-secrets/pool-linux-x86_64.cap
-      - --name=ocluster-worker
+      - --name=ocluster-worker-a
       - --allow-push=ocurrentbuilder/staging,ocurrent/opam-staging
       - --capacity=1
       - --state-dir=/var/lib/ocluster
@@ -37,7 +39,32 @@ services:
     privileged: true            # required for the Docker in Docker container to work
     restart: on-failure         # (wait for the scheduler to write the pool cap)
     volumes:
-      - 'worker-data:/var/lib/ocluster'
+      - 'worker-data-a:/var/lib/ocluster'
+      - '/var/run/docker.sock:/var/run/docker.sock'
+      - 'capnp-secrets:/capnp-secrets:ro'
+    environment:
+      - DOCKER_BUILDKIT=1
+      - DOCKER_CLI_EXPERIMENTAL=enabled
+
+  worker_b:
+    build:
+      dockerfile: docker/worker/Dockerfile
+      context: .
+    command:
+      - --connect=/capnp-secrets/pool-linux-x86_64.cap
+      - --name=ocluster-worker-b
+      - --allow-push=ocurrentbuilder/staging,ocurrent/opam-staging
+      - --capacity=1
+      - --state-dir=/var/lib/ocluster
+      - --store=rsync:/var/cache/obuilder
+      - --rsync-mode=hardlink
+      - --obuilder-healthcheck=0
+      - --verbose
+    init: true
+    privileged: true            # required for the Docker in Docker container to work
+    restart: on-failure         # (wait for the scheduler to write the pool cap)
+    volumes:
+      - 'worker-data-b:/var/lib/ocluster'
       - '/var/run/docker.sock:/var/run/docker.sock'
       - 'capnp-secrets:/capnp-secrets:ro'
     environment:
@@ -127,11 +154,12 @@ services:
       - 'ssh-credentials:/ssh/'
     environment:
       - OCAMLRUNPARAM=b
-      - CI_PROFILE=docker
+      - CI_PROFILE=dev
 
 volumes:
   ocaml-docs-ci-data:
-  worker-data:
+  worker-data-a:
+  worker-data-b:
   scheduler-data:
   capnp-secrets:
   docs-data:

--- a/src/lib/compile.ml
+++ b/src/lib/compile.ml
@@ -208,6 +208,17 @@ module Compile = struct
     in
     let* build_job = Current.Job.start_with ~pool:build_pool ~level:Mostly_harmless job in
     Current.Job.log job "Using cache hint %S" cache_hint;
+    (* TODO Log job spec here! *)
+    Current.Job.write job
+      (Fmt.str
+         "@.To reproduce locally:@.@.cat > prep.spec \
+          <<'END-OF-SPEC'@.\o033[34m%s\o033[0m@.END-OF-SPEC@.@.\
+          ocluster-client submit-obuilder --local-file prep.spec \\@.\
+          --pool linux-x86_64 --connect ocluster-submission.cap --cache-hint %s \\@.\
+          --secret ssh_privkey:id_rsa --secret ssh_pubkey:id_rsa.pub\
+          --secret ssh_config:ssh_config@.@."
+         (Spec.to_spec spec)
+         cache_hint);
     Capnp_rpc_lwt.Capability.with_ref build_job @@ fun build_job ->
     let** _ = Current_ocluster.Connection.run_job ~job build_job in
     let extract_hashes (v_compile, v_linked) line =

--- a/src/lib/compile.mli
+++ b/src/lib/compile.mli
@@ -1,8 +1,8 @@
 (** Compilation step
 
 The documentation compilation is done as an ocluster. It takes for input one prep/ folder and its
-compiled dependencies. It uses `voodoo-do` to perform the compilation, link and html generation 
-steps, outputting the results in the compile/ and html/ folders.  
+compiled dependencies. It uses `voodoo-do` to perform the compilation, link and html generation
+steps, outputting the results in the compile/ and html/ folders.
 *)
 
 type hashes = { compile_hash : string; linked_hash : string }
@@ -14,7 +14,7 @@ val hashes : t -> hashes
 (** Hash of the compiled artifacts  *)
 
 val blessing : t -> Package.Blessing.t
-(** A blessed package is compiled in the compile/packages/... hierarchy, whereas a non-blessed 
+(** A blessed package is compiled in the compile/packages/... hierarchy, whereas a non-blessed
  package is compiled in the compile/universes/... hierarchy *)
 
 val package : t -> Package.t
@@ -32,7 +32,7 @@ val v :
 (** [v ~voodoo ~cache ~blessed ~deps prep] is the ocurrent component in charge of building [prep],
 using the previously-compiled [deps]. [blessed] contains the information to figure out if [prep] is
 a blessed package or not. [cache] contains the artifacts cache metadata to track eventual changes.
-[voodoo] is the voodoo-do tool tracker. 
+[voodoo] is the voodoo-do tool tracker.
 
-Notably, if compilation artifacts already exists, then the job is a no-op. 
+Notably, if compilation artifacts already exists, then the job is a no-op.
 *)

--- a/src/lib/html.ml
+++ b/src/lib/html.ml
@@ -98,6 +98,17 @@ module Gen = struct
     in
     let* build_job = Current.Job.start_with ~pool:build_pool ~level:Mostly_harmless job in
     Current.Job.log job "Using cache hint %S" cache_hint;
+    (* TODO Log job spec here! *)
+    Current.Job.write job
+      (Fmt.str
+         "@.To reproduce locally:@.@.cat > prep.spec \
+          <<'END-OF-SPEC'@.\o033[34m%s\o033[0m@.END-OF-SPEC@.@.\
+          ocluster-client submit-obuilder --local-file prep.spec \\@.\
+          --pool linux-x86_64 --connect ocluster-submission.cap --cache-hint %s \\@.\
+          --secret ssh_privkey:id_rsa --secret ssh_pubkey:id_rsa.pub\
+          --secret ssh_config:ssh_config@.@."
+         (Spec.to_spec spec)
+         cache_hint);
     Capnp_rpc_lwt.Capability.with_ref build_job @@ fun build_job ->
     let** _ = Current_ocluster.Connection.run_job ~job build_job in
     let extract_hashes v_html_raw line =

--- a/src/lib/prep.mli
+++ b/src/lib/prep.mli
@@ -13,7 +13,7 @@ type prep
 
 val extract : job:Jobs.t -> prep Current.t -> t Current.t Package.Map.t
 
-val v : config:Config.t -> voodoo:Voodoo.Prep.t Current.t -> 
+val v : config:Config.t -> voodoo:Voodoo.Prep.t Current.t ->
         spec:Spec.t Current.t -> Jobs.t -> prep Current.t
 (** Install a package universe, extract useful files and push obtained universes on git. *)
 

--- a/src/lib/spec.ml
+++ b/src/lib/spec.ml
@@ -41,3 +41,6 @@ let to_ocluster_spec build_spec =
   let spec_str = Fmt.to_to_string Obuilder_spec.pp (build_spec |> finish) in
   let open Cluster_api.Obuilder_job.Spec in
   { spec = `Contents spec_str }
+
+let to_spec build_spec =
+  Fmt.to_to_string Obuilder_spec.pp (build_spec |> finish)

--- a/src/lib/spec.mli
+++ b/src/lib/spec.mli
@@ -14,4 +14,7 @@ val finish : t -> Obuilder_spec.t
 (** Finalize the spec and obtain the obuilder content. *)
 
 val to_ocluster_spec : t -> Cluster_api.Obuilder_job.Spec.t
+
+val to_spec : t -> string
+
 val add_rsync_retry_script : Obuilder_spec.op


### PR DESCRIPTION
This can be used to re-produce the build success/failure using ocluster-client and the cluster.

- [ ] logging spec and ocluster-client command
- [ ] testing on staging environment
- [ ] provide ocluster-client installation instructions