### PR TITLE
Change  CI_PROFILE to dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
       - 'ssh-credentials:/ssh/'
     environment:
       - OCAMLRUNPARAM=b
-      - CI_PROFILE=docker
+      - CI_PROFILE=dev
 
 volumes:
   ocaml-docs-ci-data:


### PR DESCRIPTION
CI_PROFILE=docker has a bug with composing Dockerfiles https://github.com/ocurrent/ocaml-docs-ci/issues/111 Plus this path exercises the same obuilder spec path as we use in production.