### PR TITLE
Restore "Revert "remove odoc pin: voodoo should specify odoc version""

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -17,18 +17,16 @@
  (synopsis "OCurrent pipeline for building documentation")
  (description "OCurrent pipeline for building HTML documentation for the ocaml.org website.")
  (depends
-  (ocaml
-   (>= 4.14.0))
+  (ocaml (>= 4.14.0))
   (alcotest (and (>= 1.7.0) :with-test))
   (alcotest-lwt (and (>= 1.7.0) :with-test))
-  (current
-   (>= 0.6))
+  (current (>= 0.6))
   (cstruct (< 6.1.0))
   current_web
   current_git
   current_github
   current_ocluster
-  opam-0install
+  (opam-0install (>= 0.4.3))
   (capnp-rpc-unix (>= 1.2))
   (lwt (>= 5.6.1))
   (fmt (>= 0.8.9))

--- a/ocaml-docs-ci.opam
+++ b/ocaml-docs-ci.opam
@@ -18,7 +18,7 @@ depends: [
   "current_git"
   "current_github"
   "current_ocluster"
-  "opam-0install"
+  "opam-0install" {>= "0.4.3"}
   "capnp-rpc-unix" {>= "1.2"}
   "lwt" {>= "5.6.1"}
   "fmt" {>= "0.8.9"}

--- a/src/lib/compile.ml
+++ b/src/lib/compile.ml
@@ -171,13 +171,13 @@ module Compile = struct
       voodoo : Voodoo.Do.t;
     }
 
-    let key { config; deps; prep; blessing; voodoo; base = _ } =
-      Fmt.str "v9-%s-%s-%s-%a-%s-%s"
+    let key { config = _; deps; prep; blessing; voodoo; base = _ } =
+      Fmt.str "v10-%s-%s-%s-%a-%s"
         (Package.Blessing.to_string blessing)
         (Prep.package prep |> Package.digest)
         (Prep.hash prep)
         Fmt.(list (fun f { hashes = { compile_hash; _ }; _ } -> Fmt.pf f "%s" compile_hash))
-        deps (Voodoo.Do.digest voodoo) (Config.odoc config)
+        deps (Voodoo.Do.digest voodoo)
 
     let digest t = key t |> Digest.string |> Digest.to_hex
   end

--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -178,8 +178,6 @@ let v voodoo_branch voodoo_repo cap_file jobs track_packages take_n_last_version
 let cmdliner =
   Term.(const v $ voodoo_branch $ voodoo_repo $ cap_file $ jobs $ track_packages $ take_n_last_versions $ Ssh.cmdliner)
 
-(* odoc pinned to tag 2.2.0 *)
-let odoc _ = "https://github.com/ocaml/odoc.git#103dac4c370aa2ad5aca7ba54f02f8e06adb941b"
 let pool _ = "linux-x86_64"
 let jobs t = t.jobs
 let voodoo_branch t = t.voodoo_branch

--- a/src/lib/config.mli
+++ b/src/lib/config.mli
@@ -16,16 +16,17 @@ end
 type t
 
 val cmdliner : t Cmdliner.Term.t
-val ssh : t -> Ssh.t
 
-val odoc : t -> string
-(** Odoc version pin to use. *)
+val ssh : t -> Ssh.t
 
 val pool : t -> string
 (** The ocluster pool to use *)
 
 val voodoo_repo : t -> string
+(** Voodoo repo to fetch from *)
+
 val voodoo_branch : t -> string
+(** Voodoo repo branch to use *)
 
 val ocluster_connection_prep : t -> Current_ocluster.Connection.t
 (** Connection to the cluster for Prep *)

--- a/src/lib/epoch.ml
+++ b/src/lib/epoch.ml
@@ -1,6 +1,6 @@
 type t = { config : Config.t; voodoo : Voodoo.t }
 
-let version = "v1"
+let version = "v2"
 let v config voodoo = { config; voodoo }
 
 type stage = [ `Linked | `Html ]
@@ -9,20 +9,20 @@ let digest stage t =
   let key =
     match stage with
     | `Html ->
-        Fmt.str "%s:%s:%s:%s:%s" version (Config.odoc t.config)
+        Fmt.str "%s:%s:%s:%s" version
           Voodoo.Do.(v t.voodoo |> digest)
           Voodoo.Prep.(v t.voodoo |> digest)
           Voodoo.Gen.(v t.voodoo |> digest)
     | `Linked ->
-        Fmt.str "%s:%s:%s:%s" version (Config.odoc t.config)
+        Fmt.str "%s:%s:%s" version
           Voodoo.Do.(v t.voodoo |> digest)
           Voodoo.Prep.(v t.voodoo |> digest)
   in
   key |> Digest.string |> Digest.to_hex
 
 let pp f t =
-  Fmt.pf f "docs-ci: %s\nodoc: %s\nvoodoo do: %a\nvoodoo prep: %a\nvoodoo gen: %a" version
-    (Config.odoc t.config) Current_git.Commit_id.pp
+  Fmt.pf f "docs-ci: %s\nvoodoo do: %a\nvoodoo prep: %a\nvoodoo gen: %a" version
+    Current_git.Commit_id.pp
     Voodoo.Do.(v t.voodoo |> commit)
     Current_git.Commit_id.pp
     Voodoo.Prep.(v t.voodoo |> commit)

--- a/src/lib/html.ml
+++ b/src/lib/html.ml
@@ -72,10 +72,10 @@ module Gen = struct
   module Key = struct
     type t = { config : Config.t; compile : Compile.t; voodoo : Voodoo.Gen.t; base : Spec.t }
 
-    let key { config; compile; voodoo; base = _ } =
-      Fmt.str "v6-%s-%s-%s-%s"
+    let key { config = _; compile; voodoo; base = _ } =
+      Fmt.str "v7-%s-%s-%s"
         (Compile.package compile |> Package.digest)
-        (Compile.hashes compile).linked_hash (Voodoo.Gen.digest voodoo) (Config.odoc config)
+        (Compile.hashes compile).linked_hash (Voodoo.Gen.digest voodoo)
 
     let digest t = key t |> Digest.string |> Digest.to_hex
   end

--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -122,9 +122,9 @@ let remote_uri commit =
 
 let digest t =
   let key =
-    Fmt.str "%s\n%s\n%s\n%s\n"
+    Fmt.str "%s\n%s\n%s\n"
       (Git.Commit_id.hash t.voodoo_prep)
-      (Git.Commit_id.hash t.voodoo_do) (Git.Commit_id.hash t.voodoo_gen) (Config.odoc t.config)
+      (Git.Commit_id.hash t.voodoo_do) (Git.Commit_id.hash t.voodoo_gen)
   in
   Digest.(string key |> to_hex)
 
@@ -160,14 +160,11 @@ module Do = struct
     |> Spec.add
          [
            run ~network "sudo apt-get update && sudo apt-get install -yy m4";
-           run ~network ~cache
-             "opam pin -ny odoc %s && opam depext -iy odoc &&  opam exec -- odoc --version"
-             (Config.odoc t.config);
            run ~network ~cache "opam pin -ny %s  && opam depext -iy voodoo-do" (remote_uri t.commit);
            run "cp $(opam config var bin)/odoc $(opam config var bin)/voodoo-do /home/opam";
          ]
 
-  let digest t = Git.Commit_id.hash t.commit ^ Config.odoc t.config
+  let digest t = Git.Commit_id.hash t.commit
   let commit t = t.commit
 end
 
@@ -184,14 +181,11 @@ module Gen = struct
          [
            run ~network
              "sudo apt-get update && sudo apt-get install -yy m4";
-           run ~network ~cache
-             "opam pin -ny odoc %s && opam depext -iy odoc &&  opam exec -- odoc --version"
-             (Config.odoc t.config);
            run ~network ~cache "opam pin -ny %s  && opam depext -iy voodoo-gen"
              (remote_uri t.commit);
            run "cp $(opam config var bin)/odoc $(opam config var bin)/voodoo-gen /home/opam";
          ]
 
-  let digest t = Git.Commit_id.hash t.commit ^ Config.odoc t.config
+  let digest t = Git.Commit_id.hash t.commit
   let commit t = t.commit
 end


### PR DESCRIPTION
Reverts ocurrent/ocaml-docs-ci#116

Needs testing on ocaml-docs-ci and voodoo staging before pushing to live.