### PR TITLE
Check for job succeeded in retry logic.

### DIFF
--- a/src/lib/compile.mli
+++ b/src/lib/compile.mli
@@ -20,6 +20,12 @@ val blessing : t -> Package.Blessing.t
 val package : t -> Package.t
 (** The compiled package *)
 
+val extract_hashes :
+  (Storage.id_hash option * Storage.id_hash option) * string list ->
+  string ->
+  (Storage.id_hash option * Storage.id_hash option) * string list
+(** Function used to parse log lines *)
+
 val v :
   generation:Epoch.t Current.t ->
   config:Config.t ->

--- a/src/lib/prep.ml
+++ b/src/lib/prep.ml
@@ -229,10 +229,10 @@ module Prep = struct
       match Storage.parse_hash ~prefix:"HASHES" line with
       | Some value -> ((value :: git_hashes, failed), retriable_errors)
       | None -> (
-          if retry_conditions line then
-            ((git_hashes, failed), line :: retriable_errors)
-          else if escape_on_success line then ((git_hashes, failed), [])
+          if escape_on_success line then ((git_hashes, failed), [])
             (* ignore retriable errors if the job has succeeded *)
+          else if retry_conditions line then
+            ((git_hashes, failed), line :: retriable_errors)
           else
             match String.split_on_char ':' line with
             | [ prev; branch ]

--- a/src/lib/prep.ml
+++ b/src/lib/prep.ml
@@ -220,11 +220,19 @@ module Prep = struct
           (fun acc str -> acc || Astring.String.is_infix ~affix:str log_line)
           false retry_on
       in
+      let escape_on_success log_line =
+        let escape_on = [ "Job succeeded" ] in
+        List.fold_left
+          (fun acc str -> acc || Astring.String.is_infix ~affix:str log_line)
+          false escape_on
+      in
       match Storage.parse_hash ~prefix:"HASHES" line with
       | Some value -> ((value :: git_hashes, failed), retriable_errors)
       | None -> (
           if retry_conditions line then
             ((git_hashes, failed), line :: retriable_errors)
+          else if escape_on_success line then ((git_hashes, failed), [])
+            (* ignore retriable errors if the job has succeeded *)
           else
             match String.split_on_char ':' line with
             | [ prev; branch ]

--- a/test/lib/test_compile.ml
+++ b/test/lib/test_compile.ml
@@ -1,0 +1,71 @@
+module Compile = Docs_ci_lib.Compile
+
+let test_extract_hashes_no_retry _switch () =
+  let log_lines =
+    "compile/u/d5bd534a65ac29b409950ab82ea7ec10/stdlib-shims/0.3.0/page-doc.odoc\n\
+    \  compile/u/d5bd534a65ac29b409950ab82ea7ec10/ppx_derivers/1.2.1/1.2.1/\n\
+    \  compile/u/d5bd534a65ac29b409950ab82ea7ec10/ppx_derivers/1.2.1/1.2.1/lib/\n\
+     compile/u/d5bd534a65ac29b409950ab82ea7ec10/ppx_derivers/1.2.1/1.2.1/lib/ppx_derivers/\n"
+  in
+  let expected = 0 in
+  let result = Compile.extract_hashes ((None, None), []) log_lines in
+  Alcotest.(check int) "" expected (List.length (snd result)) |> Lwt.return
+
+let test_extract_hashes_rsync_retry _switch () =
+  let log_lines =
+    "Warning: Permanently added \
+     '[staging.docs.ci.ocaml.org]:2222,[51.158.163.148]:2222' (ECDSA) to the \
+     list of known hosts.\n\
+    \  ssh: connect to host staging.docs.ci.ocaml.org port 2222: Connection \
+     timed out\n\
+    \  rsync: connection unexpectedly closed (0 bytes received so far) \
+     [Receiver]\n\
+    \  rsync error: unexplained error (code 255) at io.c(228) [Receiver=3.2.3]"
+  in
+  let result = Compile.extract_hashes ((None, None), []) log_lines in
+  Alcotest.(check string) "" log_lines (List.hd (snd result)) |> Lwt.return
+
+let test_extract_hashes_several_retry _switch () =
+  let log_lines =
+    "Warning: Permanently added \
+     '[staging.docs.ci.ocaml.org]:2222,[51.158.163.148]:2222' (ECDSA) to the \
+     list of known hosts.\n\
+    \  ssh: connect to host staging.docs.ci.ocaml.org port 2222: Connection \
+     timed out\n\
+    \ Temporary failure due to some unknown cause\n\
+    \ Could not resolve host\n\
+    \      rsync error: unexplained error (code 255) at io.c(228) \
+     [Receiver=3.2.3]"
+  in
+  let result = Compile.extract_hashes ((None, None), []) log_lines in
+  Alcotest.(check string) "" log_lines (List.hd (snd result)) |> Lwt.return
+
+let test_extract_hashes_succeeded_no_retry _switch () =
+  let log_lines =
+    "Warning: Permanently added \
+     '[staging.docs.ci.ocaml.org]:2222,[51.158.163.148]:2222' (ECDSA) to the \
+     list of known hosts.\n\
+    \  ssh: connect to host staging.docs.ci.ocaml.org port 2222: Connection \
+     timed out\n\
+    \ Temporary failure due to some unknown cause\n\
+    \ Could not resolve host\n\
+    \      rsync error: unexplained error (code 255) at io.c(228) \
+     [Receiver=3.2.3]\n\
+    \ Job succeeded"
+  in
+  let expected = 0 in
+  let result = Compile.extract_hashes ((None, None), []) log_lines in
+  List.iteri (fun i s -> Printf.printf "%d: %s" i s) (snd result);
+  Alcotest.(check int) "" expected (List.length (snd result)) |> Lwt.return
+
+let tests =
+  [
+    Alcotest_lwt.test_case "extract_hashes_no_retry" `Quick
+      test_extract_hashes_no_retry;
+    Alcotest_lwt.test_case "extract_hashes_rsync_retry" `Quick
+      test_extract_hashes_rsync_retry;
+    Alcotest_lwt.test_case "extract_hashes_several_retry" `Quick
+      test_extract_hashes_several_retry;
+    Alcotest_lwt.test_case "extract_hashes_succeeded_no_retry" `Quick
+      test_extract_hashes_succeeded_no_retry;
+  ]

--- a/test/lib/test_lib.ml
+++ b/test/lib/test_lib.ml
@@ -1,2 +1,4 @@
 let () =
-  Lwt_main.run @@ Alcotest_lwt.run "test_lib" [ ("retry", Test_retry.tests) ]
+  Lwt_main.run
+  @@ Alcotest_lwt.run "test_lib"
+       [ ("retry", Test_retry.tests); ("compile", Test_compile.tests) ]


### PR DESCRIPTION
It looks like the `rsync: connection unexpectedly closed` string is not definitively indicative of an error.  There are examples of jobs that succeed that have this string in their logs but are currently retried and eventually marked as failed. This PR attempts to fix that by explicitly checking on the `Job succeeded` string in logs.