### PR TITLE
Pipeline step to record build information.

### DIFF
--- a/src/lib/index.ml
+++ b/src/lib/index.ml
@@ -1,0 +1,15 @@
+let record (package : Package.t) (config : Config.t)
+    (step_list : Monitor.step list) (voodoo_do_commit : string)
+    (voodoo_gen_commit : string) =
+  Log.info (fun f ->
+      f
+        "[Index] Package: %s:%s Voodoo-branch: %s Voodoo-repo: %s \
+         Voodoo-do-commit: %s Voodoo-gen-commit: %s Step-list: %a"
+        (Package.opam package |> OpamPackage.name_to_string)
+        (Package.opam package |> OpamPackage.version_to_string)
+        (Config.voodoo_branch config)
+        (Config.voodoo_repo config)
+        voodoo_do_commit voodoo_gen_commit
+        (Format.pp_print_list Monitor.pp_step)
+        step_list);
+  ()

--- a/src/lib/monitor.ml
+++ b/src/lib/monitor.ml
@@ -394,7 +394,6 @@ let lookup_status' t package : state =
   in
   match x with None -> Running | Some (_, _, s) -> s
 
-(* val lookup_steps : t -> name:string -> (package_steps list, string) result *)
 let lookup_steps' t (package : OpamPackage.t) =
   let status = opam_package_state t package in
   let package_pipeline_tree = get_opam_package_info t package in

--- a/src/lib/monitor.mli
+++ b/src/lib/monitor.mli
@@ -14,7 +14,9 @@ type state =
    | BuildHtml *)
 
 type step_status = Err of string | Active | Blocked | OK
+
 type step = { typ : string; job_id : string option; status : step_status }
+[@@deriving show, eq]
 
 val make : unit -> t
 (** Create a monitor. *)


### PR DESCRIPTION
This PR is the first in an effort to make it easier to measure the health of a pipeline run.

To record build data, we introduce a pipeline step that collects information and logs it. In subsequent PRs we will introduce database machinery to persist this information.