### PR TITLE
Remove v1 solver cache and some logging lines

### DIFF
--- a/src/lib/opam_repository.ml
+++ b/src/lib/opam_repository.ml
@@ -7,7 +7,7 @@ module Log = Solver_api.Solver.Log
     Resolve for a packages revdeps.
 
     Don't want to scope on opam_repository *)
-let oldest_commit_with ~job ~from pkgs =
+let oldest_commit_with ~from pkgs =
   let paths =
     pkgs
     |> List.map (fun pkg ->
@@ -16,7 +16,6 @@ let oldest_commit_with ~job ~from pkgs =
            Printf.sprintf "packages/%s/%s.%s" name name version)
   in
   let clone_path = Current_git.Commit.repo from in
-  Current.Job.log job "clone_path %a" Current_git.Commit.pp from;
   (* Equivalent to: git -C path log -n 1 --format=format:%H from -- paths *)
   let cmd =
     "git"
@@ -30,8 +29,5 @@ let oldest_commit_with ~job ~from pkgs =
     :: "--"
     :: paths
   in
-  Current.Job.log job "oldest_commit_with %a"
-    (Fmt.list ~sep:Fmt.sp Fmt.string)
-    cmd;
   let cmd = ("", Array.of_list cmd) in
   Process.pread cmd >|= String.trim

--- a/src/lib/opam_repository.mli
+++ b/src/lib/opam_repository.mli
@@ -1,11 +1,7 @@
 val oldest_commit_with :
-  job:Current.Job.t ->
-  from:Current_git.Commit.t ->
-  OpamPackage.t list ->
-  string Lwt.t
+  from:Current_git.Commit.t -> OpamPackage.t list -> string Lwt.t
 (** Use "git-log" to find the oldest commit with these package versions. This
     avoids invalidating the Docker build cache on every update to
     opam-repository.
 
-    @param job The active ocurrent job, used for logging.
     @param from The commit at which to begin the search. *)

--- a/src/lib/solver.ml
+++ b/src/lib/solver.ml
@@ -92,32 +92,6 @@ module Cache = struct
     let name_version = Track.pkg track |> OpamPackage.version_to_string in
     Fpath.(Current.state_dir id / name / name_version / digest)
 
-  module V1 = struct
-    (* Migration from the old cached results *)
-    let id = "solver-cache-v1"
-
-    type cache_value = Package.t option
-
-    let fname = fname id
-
-    let mem track =
-      let fname = fname track in
-      match Bos.OS.Path.exists fname with Ok true -> true | _ -> false
-
-    let remove track =
-      let fname = fname track in
-      Bos.OS.Path.delete fname |> Result.get_ok
-
-    let read track : cache_value option =
-      let fname = fname track in
-      try
-        let file = open_in (Fpath.to_string fname) in
-        let result = Marshal.from_channel file in
-        close_in file;
-        Some result
-      with Failure _ -> None
-  end
-
   let id = "solver-cache-" ^ solver_version
 
   type cache_value = (Package.t, string) result
@@ -128,7 +102,7 @@ module Cache = struct
     let fname = fname track in
     match Bos.OS.Path.exists fname with
     | Ok true -> true
-    | Ok false | Error _ -> V1.mem track
+    | Ok false | Error _ -> false
 
   let write ((track, value) : Track.t * cache_value) =
     let fname = fname track in
@@ -144,16 +118,7 @@ module Cache = struct
       let result = Marshal.from_channel file in
       close_in file;
       Some result
-    with Failure _ | Sys_error _ -> (
-      match V1.read track with
-      | None -> None
-      | Some v ->
-          let result =
-            Option.to_result ~none:"v1 solver did not record failure logs" v
-          in
-          write (track, result);
-          V1.remove track;
-          Some result)
+    with Failure _ | Sys_error _ -> None
 end
 
 type key = Track.t
@@ -221,15 +186,12 @@ module Solver = struct
         | None -> Lwt.return true
         | Some (Error _) -> Lwt.return true
         | Some (Ok package) ->
-            Current.Job.log job "check_cache for %s"
-              (Yojson.Safe.to_string (Track.to_yojson key));
             let cached_opam_repo_sha = Package.commit package in
             let opam_packages =
               Package.all_deps package |> List.map Package.opam
             in
             let+ commit =
               Opam_repository.oldest_commit_with opam_packages ~from:opam_commit
-                ~job
             in
             (* If the git sha found is the same, use the cached result
                otherwise we need to resolve as something changed.


### PR DESCRIPTION
Since we purged the solver-cache-v1 directory on live we no longer have v1 solver results. This PR removes the support for reading and writing them. I also removed some of the informational logging for the solver as it was too much detail for production.