### PR TITLE
Adds voodoo repo, branch and odoc to health cli output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ suitable for ocaml.org server to present.
 
 Get the code with:
 
-``` shell
+```shell
 git clone --recursive https://github.com/ocurrent/ocaml-docs-ci.git
 cd ocaml-docs-ci
 ```
@@ -20,7 +20,7 @@ Note: you need to clone with --recursive because this project uses submodules (i
 
 Then you need an opam 2.1 switch using OCaml 4.14. Recommend using this command to setup a local switch just for `docs-ci`.
 
-``` shell
+```shell
 # Create a local switch with packages and test dependencies installed
 opam switch create . 4.14.1 --deps-only --with-test -y
 
@@ -47,7 +47,7 @@ For further details on how `docs-ci` works read the [pipeline diagram](doc/pipel
 Environments:
 
 | Environment | www                       | pipeline                          | git branch | data                               | voodoo branch |
-|-------------|---------------------------|-----------------------------------|------------|------------------------------------|---------------|
+| ----------- | ------------------------- | --------------------------------- | ---------- | ---------------------------------- | ------------- |
 | Production  | https://ocaml.org         | https://docs.ci.ocaml.org         | live       | http://docs-data.ocaml.org         | main          |
 | Staging     | https://staging.ocaml.org | https://staging.docs.ci.ocaml.org | staging    | http://staging.docs-data.ocaml.org | staging       |
 
@@ -94,14 +94,24 @@ dune exec -- ocaml-docs-ci \
 
 A [docker-compose.yml](docker-compose.yml) is provided to setup an entire `docs-ci` environment including:
 
- * ocluster scheduler
- * ocluster Linux x86 worker
- * nginx webserver for generated docs
- * docs-ci built from the local git checkout
+- ocluster scheduler
+- ocluster Linux x86 worker
+- nginx webserver for generated docs
+- docs-ci built from the local git checkout
 
 Run this command to create an environment:
 
-``` shell
+```shell
 $ docker-compose -f docker-compose.yml up
 ```
+
 You should then be able to watch the pipeline in action at `http://localhost:8080`.
+
+### Migrations
+
+Migrations are managed using omigrate. If you are using an opam switch for ocaml-docs-ci then omigrate should be installed and you can create a new migration by doing this from the project root:
+
+omigrate create --dir migrations <migration-name>
+This will create timestamped files in the migrations directory that you can then populate with the sql necessary to introduce and remove the migration (in the up and down files respectively).
+
+Migrations will not run unless the --migration-path flag is present when invoking ocaml-docs-ci-service.

--- a/migrations/20230921005634_add_attributes_to_pipeline.down.sql
+++ b/migrations/20230921005634_add_attributes_to_pipeline.down.sql
@@ -1,0 +1,8 @@
+ALTER TABLE docs_ci_pipeline_index
+DROP COLUMN voodoo_branch TEXT;
+
+ALTER TABLE docs_ci_pipeline_index
+DROP COLUMN voodoo_repo TEXT;
+
+ALTER TABLE docs_ci_pipeline_index
+DROP COLUMN odoc_commit TEXT;

--- a/migrations/20230921005634_add_attributes_to_pipeline.up.sql
+++ b/migrations/20230921005634_add_attributes_to_pipeline.up.sql
@@ -1,0 +1,8 @@
+ALTER TABLE docs_ci_pipeline_index
+ADD COLUMN voodoo_branch TEXT;
+
+ALTER TABLE docs_ci_pipeline_index
+ADD COLUMN voodoo_repo TEXT;
+
+ALTER TABLE docs_ci_pipeline_index
+ADD COLUMN odoc_commit TEXT;

--- a/src/api/pipeline/client.ml
+++ b/src/api/pipeline/client.ml
@@ -153,6 +153,9 @@ module Pipeline = struct
     let voodoo_do = voodoo_do_commit_get h in
     let voodoo_prep = voodoo_prep_commit_get h in
     let voodoo_gen = voodoo_gen_commit_get h in
+    let voodoo_branch = voodoo_branch_get h in
+    let voodoo_repo = voodoo_repo_get h in
+    let odoc_commit = odoc_commit_get h in
     let failed_packages = failing_packages_get h |> Int64.to_int in
     let running_packages = running_packages_get h |> Int64.to_int in
     let passed_packages = passing_packages_get h |> Int64.to_int in
@@ -163,6 +166,9 @@ module Pipeline = struct
         ("voodoo_do", `String voodoo_do);
         ("voodoo_prep", `String voodoo_prep);
         ("voodoo_gen", `String voodoo_gen);
+        ("odoc", `String odoc_commit);
+        ("voodoo_repo", `String voodoo_repo);
+        ("voodoo_branch", `String voodoo_branch);
         ("failed_packages", `Int failed_packages);
         ("running_packages", `Int running_packages);
         ("passed_packages", `Int passed_packages);

--- a/src/api/pipeline/schema.capnp
+++ b/src/api/pipeline/schema.capnp
@@ -123,6 +123,9 @@ struct PipelineHealth {
   failingPackages @5 :Int64;
   passingPackages @6 :Int64;
   runningPackages @7 :Int64;
+  voodooBranch @8 :Text;
+  voodooRepo @9 :Text;
+  odocCommit @10 :Text;
 }
 
 interface Package {

--- a/src/lib/record.ml
+++ b/src/lib/record.ml
@@ -1,3 +1,5 @@
+module Git = Current_git
+
 module Record = struct
   type t = No_context
 
@@ -29,14 +31,20 @@ module Record = struct
 
     let generation = Epoch.v config voodoo in
     let voodoo_do_commit = Voodoo.Do.v voodoo |> Voodoo.Do.digest in
-    let voodoo_gen_commit = Voodoo.Gen.v voodoo |> Voodoo.Gen.digest in
+    let voodoo_gen_commit =
+      Voodoo.Gen.v voodoo |> Voodoo.Gen.commit |> Git.Commit_id.hash
+    in
+    let voodoo_repo = Config.voodoo_repo config in
+    let voodoo_branch = Config.voodoo_branch config in
+    let odoc_commit = Config.odoc config in
     let voodoo_prep_commit = Voodoo.Prep.v voodoo |> Voodoo.Prep.digest in
     let epoch_linked = (Epoch.digest `Linked) generation in
     let epoch_html = (Epoch.digest `Html) generation in
 
     let result =
       Index.record_new_pipeline ~voodoo_do_commit ~voodoo_gen_commit
-        ~voodoo_prep_commit ~epoch_html ~epoch_linked
+        ~voodoo_prep_commit ~voodoo_repo ~voodoo_branch ~odoc_commit ~epoch_html
+        ~epoch_linked
     in
     match result with
     | Ok pipeline_id -> Lwt.return_ok (pipeline_id |> Int64.to_int)

--- a/src/pipelines/api_impl.ml
+++ b/src/pipelines/api_impl.ml
@@ -170,6 +170,9 @@ let make ~monitor =
              voodoo_do_commit_set health_slot pipeline_data.voodoo_do;
              voodoo_gen_commit_set health_slot pipeline_data.voodoo_gen;
              voodoo_prep_commit_set health_slot pipeline_data.voodoo_prep;
+             voodoo_branch_set health_slot pipeline_data.voodoo_branch;
+             voodoo_repo_set health_slot pipeline_data.voodoo_repo;
+             odoc_commit_set health_slot pipeline_data.odoc_commit;
              epoch_html_set health_slot pipeline_data.epoch_html;
              epoch_linked_set health_slot pipeline_data.epoch_linked;
              failing_packages_set health_slot @@ Int64.of_int failed_count;


### PR DESCRIPTION
Adds new columns to the `docs_ci_pipeline_index` table to record voodoo repo, branch and odoc information pertaining to a pipeline run.

json output of the `health` command is now:

```
{
  "latest": {
    "epoch_html": "ae8bf595b8594945ee40c58377e03730",
    "epoch_linked": "5daeecab2ad7a2d07a12742d4cc0ab6f",
    "voodoo_do": "67ccabec49b5f4d24147839291fcae7c19d3e8c9",
    "voodoo_prep": "67ccabec49b5f4d24147839291fcae7c19d3e8c9",
    "voodoo_gen": "67ccabec49b5f4d24147839291fcae7c19d3e8c9",
    "odoc": "https://github.com/ocaml/odoc.git#103dac4c370aa2ad5aca7ba54f02f8e06adb941b",
    "voodoo_repo": "https://github.com/ocaml-doc/voodoo.git",
    "voodoo_branch": "main",
    "failed_packages": 0,
    "running_packages": 15,
    "passed_packages": 0
  },
```