### PR TITLE
Pin odoc.2.3.0

### DIFF
--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -212,9 +212,9 @@ let cmdliner =
     $ take_n_last_versions
     $ Ssh.cmdliner)
 
-(* odoc pinned to tag 2.2.0 *)
+(* odoc pinned to tag 2.3.0 *)
 let odoc _ =
-  "https://github.com/ocaml/odoc.git#103dac4c370aa2ad5aca7ba54f02f8e06adb941b"
+  "https://github.com/ocaml/odoc.git#5b0b056f7758f85cd49c756874aae874d375a0b7"
 
 let pool _ = "linux-x86_64"
 let jobs t = t.jobs


### PR DESCRIPTION
We want to upgrade odoc to 2.3.0 in voodoo (https://github.com/ocaml-doc/voodoo/pull/128) to be able to use the last features, and we need to keep ocaml-docs-ci in sync!