### PR TITLE
switch odoc to version 2.4.0

### DIFF
--- a/src/lib/config.ml
+++ b/src/lib/config.ml
@@ -212,9 +212,9 @@ let cmdliner =
     $ take_n_last_versions
     $ Ssh.cmdliner)
 
-(* odoc pinned to tag 2.2.2 *)
+(* odoc pinned to tag 2.4.0 *)
 let odoc _ =
-  "https://github.com/ocaml/odoc.git#34a48e2543f6ea5716e9ee922954fa0917561dd7"
+  "https://github.com/ocaml/odoc.git#c8d3ba1604cd6a2bb7155afe10ecb596517e9e47"
 
 let pool _ = "linux-x86_64"
 let jobs t = t.jobs


### PR DESCRIPTION
This switches the odoc version used to version 2.4.0. This is the version of odoc that supports search. 

The intend being this is to be a step towards using [sherlodoc](https://github.com/art-w/sherlodoc/tree/jsoo) on ocaml. This will be an improvement over the current search because there is fuzzy type search like hoogle, and because it is tailored and tested for ocaml.

This will also allow updating the online version of sherlodoc, which needs as input the odocl file generated by this CI. The new version of sherlodoc is only compatible with odoc.2.4.0. As the format of the odocl file is not backward-compatible, the odocl files currently generated are not suitable to be consumed by the new sherlodoc, which has loads of new features.

I am not sure my change is correct, I have run the tests and they pass, but maybe more testing is required. Odoc itself should be backwards compatible.