### PR TITLE
reduce/optimize the number of universes (DO NOT MERGE)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -116,7 +116,8 @@ services:
       # - --voodoo-branch=""    # Git branch from the voodoo repository
       - --jobs=6
       - --limit=1               # Only build the most recent version of each package
-      - --filter=capnp-rpc      # NOTE Only build capnp-rpc documentation.
+      - --filter=cmdliner      # NOTE Only build capnp-rpc documentation.
+      # - --filter=current_github      # NOTE Only build capnp-rpc documentation.
       - --capnp-listen-address=tcp:0.0.0.0:9080
       - --capnp-public-address=tcp:localhost:9080
       - --migration-path=/migrations

--- a/src/counts.ml
+++ b/src/counts.ml
@@ -1,0 +1,43 @@
+let rec take n lst =
+  match (n, lst) with
+  | 0, _ -> []
+  | _, [] -> []
+  | n, a :: q -> a :: take (n - 1) q
+
+let take = function Some n -> take n | None -> Fun.id
+
+let get_file path =
+  Lwt_io.with_file ~mode:Input (Fpath.to_string path) Lwt_io.read
+
+let get_versions ~limit path =
+  let open Lwt.Syntax in
+  let open Rresult in
+  Bos.OS.Dir.contents path
+  >>| (fun versions ->
+        versions
+        |> Lwt_list.map_p (fun path ->
+               let+ content = get_file Fpath.(path / "opam") in
+               ( path |> Fpath.basename |> OpamPackage.of_string,
+                 Digest.(string content |> to_hex) )))
+  |> Result.get_ok
+  |> Lwt.map (fun v ->
+         v
+         |> List.sort (fun a b -> -OpamPackage.compare (fst a) (fst b))
+         |> take limit)
+
+let dir = Fpath.v "/home/alpha/hack/draft-clone/opam-repository"
+let limit = Some 2000
+
+let result =
+  let open Lwt.Syntax in
+  let open Rresult in
+  Bos.OS.Dir.contents Fpath.(dir / "packages") >>| fun packages ->
+  packages
+  |> Lwt_list.map_s (get_versions ~limit)
+  |> Lwt.map (fun v -> List.flatten v)
+  |> Lwt.map (fun v -> Fmt.pr "packages: %d" (List.length v))
+
+let () =
+  match result with
+  | Ok rr -> Lwt_main.run rr
+  | _ -> Fmt.failwith "Error happend"

--- a/src/dune
+++ b/src/dune
@@ -1,7 +1,7 @@
-(executable
- (public_name ocaml-docs-ci)
+(executables
+ (public_names ocaml-docs-ci stats counts)
  (package ocaml-docs-ci)
- (name ocaml_docs_ci)
+ (names ocaml_docs_ci stats counts)
  (libraries
   current
   current.cache

--- a/src/lib/jobs.ml
+++ b/src/lib/jobs.ml
@@ -2,6 +2,7 @@ type t = { install : Package.t; prep : Package.t list }
 (** A job is one package to install, from which a set of prep folders can be
     derived. *)
 
+let install_pkg t = t.install
 let pp f (t : t) = Fmt.pf f "%a" Package.pp t.install
 let compare (a : t) (b : t) = Package.compare a.install b.install
 

--- a/src/lib/mld.ml
+++ b/src/lib/mld.ml
@@ -142,7 +142,7 @@ module Gen = struct
               (OpamPackage.Version.Map.add version root_odoc)
               OpamPackage.Version.Map.empty !packages
         else
-          let digest = package |> Package.universe |> Package.Universe.hash in
+          let digest = package |> Package.universes_hash in
           universes :=
             StringMap.(
               add digest

--- a/src/lib/package.mli
+++ b/src/lib/package.mli
@@ -7,20 +7,18 @@ module rec Universe : sig
 
   val deps : t -> Package.t list
   (** Retrieve the list of dependencies *)
-
-  val hash : t -> string
-  (** Get the universe hash *)
 end
 
 and Package : sig
   type t
   (** A package in the ocaml-docs-ci sense: it's composed of the package name,
-      version, and its dependency universe. *)
+      ver ion, and its dependency universe. *)
 end
 
 type t = Package.t
 
 val make :
+  ?group:OpamPackage.t list ->
   blacklist:string list ->
   commit:string ->
   root:OpamPackage.t ->
@@ -38,7 +36,9 @@ val opam : t -> OpamPackage.t
 val universe : t -> Universe.t
 val digest : t -> string
 val commit : t -> string
+val universes_hash : t -> string
 val id : t -> string
+val group : t -> t list option
 
 module Map : Map.S with type key = t
 module Set : Set.S with type elt = t

--- a/src/lib/prep.ml
+++ b/src/lib/prep.ml
@@ -21,7 +21,7 @@ let not_base x =
 let universes_assoc packages =
   packages
   |> List.map (fun pkg ->
-         let hash = pkg |> Package.universe |> Package.Universe.hash in
+         let hash = pkg |> Package.universes_hash in
          let name = pkg |> Package.opam |> OpamPackage.name_to_string in
          name ^ ":" ^ hash)
   |> String.concat ","

--- a/src/lib/solver.mli
+++ b/src/lib/solver.mli
@@ -4,11 +4,13 @@ type t
 type key
 
 val keys : t -> key list
-val failures : t -> (OpamPackage.t * string) list
+val failures : t -> (OpamPackage.t list * string) list
 val get : key -> Package.t
 
 val incremental :
-  config:Config.t ->
+  ?group:bool ->
+  ?nb_jobs:int ->
+  ?config:Config.t ->
   blacklist:string list ->
   opam:Git.Commit.t Current.t ->
   Track.t list Current.t ->

--- a/src/lib/storage.ml
+++ b/src/lib/storage.ml
@@ -27,7 +27,7 @@ let to_base_repo = function
 
 let base_folder ~blessed ~prep package =
   let universes = if prep then "universes" else "u" in
-  let universe = Package.universe package |> Package.Universe.hash in
+  let universe = Package.universes_hash package in
   let opam = Package.opam package in
   let name = OpamPackage.name_to_string opam in
   let version = OpamPackage.version_to_string opam in

--- a/src/lib/track.mli
+++ b/src/lib/track.mli
@@ -1,12 +1,11 @@
 type t [@@deriving yojson]
 
 val digest : t -> string
-val pkg : t -> OpamPackage.t
+val pkgs : t -> OpamPackage.t list
 
 val v :
+  ?group:bool ->
   limit:int option ->
   filter:string list ->
   Current_git.Commit.t Current.t ->
   t list Current.t
-
-module Map : OpamStd.MAP with type key = t

--- a/src/stats.ml
+++ b/src/stats.ml
@@ -1,0 +1,261 @@
+open Lwt.Infix
+open Current.Syntax
+open Docs_ci_lib
+module Git = Current_git
+
+let program_name = "stats"
+let job_deps_sha job = job.Jobs.install |> Package.universes_hash
+
+let ratio ~all ~part =
+  if all = 0 then 0.0
+  else
+    let all = float_of_int all in
+    let part = float_of_int part in
+    part /. all *. 100.
+
+let schedule_jobs ~targets all_packages_jobs =
+  (* Schedule a somewhat small set of jobs to obtain at least one universe for each package.version *)
+  Jobs.schedule ~targets all_packages_jobs |> List.sort Jobs.compare
+
+let summary ~job ~all_packages_jobs_success ~all_opam_packages_failures
+    ~all_opam_packages_success ~reduced_jobs ~schedule_jobs ~kind =
+  Current.Job.log job "%s> The solved jobs success    : %d" kind
+    all_packages_jobs_success;
+
+  Current.Job.log job "%s> The opam packages success  : %d" kind
+    all_opam_packages_success;
+
+  Current.Job.log job "%s> The opam packages failures : %d" kind
+    all_opam_packages_failures;
+
+  Current.Job.log job "%s> Scheduled jobs             : %d" kind schedule_jobs;
+
+  Current.Job.log job "%s> Coverage                   : %d/%d (%.2f ratio)" kind
+    all_opam_packages_success
+    (all_opam_packages_success + all_opam_packages_failures)
+    (ratio
+       ~all:(all_opam_packages_success + all_opam_packages_failures)
+       ~part:all_opam_packages_success);
+
+  Current.Job.log job "%s> Reduced jobs (by deps hashes) : %d" kind reduced_jobs
+
+let solve_summary job solve kind =
+  let all_failures = solve |> Solver.failures in
+  let all_packages_jobs = solve |> Solver.keys |> List.rev_map Solver.get in
+  let all_packages =
+    all_packages_jobs |> List.rev_map Package.all_deps |> List.flatten
+  in
+  let schedule_jobs =
+    schedule_jobs
+      ~targets:(all_packages |> Package.Set.of_list)
+      all_packages_jobs
+  in
+  let all_opam_packages =
+    all_packages
+    |> List.rev_map (fun pkg -> Package.opam pkg)
+    |> OpamPackage.Set.of_list
+  in
+  let all_opam_packages_failures =
+    List.rev_map fst all_failures
+    |> List.flatten
+    |> List.filter (fun opam ->
+           not (OpamPackage.Set.mem opam all_opam_packages))
+  in
+  let reduced_jobs =
+    let uniq_deps = Hashtbl.create 100 in
+    List.iter
+      (fun job -> Hashtbl.replace uniq_deps (job_deps_sha job) job)
+      schedule_jobs;
+    Hashtbl.to_seq_values uniq_deps |> List.of_seq |> List.sort Jobs.compare
+  in
+  summary ~job
+    ~all_packages_jobs_success:(List.length all_packages_jobs)
+    ~all_opam_packages_success:(OpamPackage.Set.cardinal all_opam_packages)
+    ~all_opam_packages_failures:
+      (OpamPackage.Set.cardinal
+      @@ OpamPackage.Set.of_list all_opam_packages_failures)
+    ~reduced_jobs:(List.length reduced_jobs)
+    ~schedule_jobs:(List.length schedule_jobs)
+    ~kind
+
+module Stats = struct
+  type t = { solve_group : Solver.t; solve_ungroup : Solver.t }
+
+  let id = "show-cmd"
+
+  module Key = Current.String
+  module Value = Current.Unit
+
+  let build solve job key =
+    Current.Job.start job ~level:Current.Level.Harmless >>= fun () ->
+    Current.Job.log job "opam-repository commit : %s" key;
+    let { solve_ungroup; solve_group } = solve in
+
+    (* Ungroup packages (current implementation) *)
+    Current.Job.log job "";
+    Current.Job.log job "Ungrouped packages (default)";
+    solve_summary job solve_ungroup "default";
+
+    (* Gropued packages by repo *)
+    Current.Job.log job "";
+    Current.Job.log job "Grouped packages by repo";
+    solve_summary job solve_group "grouped";
+
+    let all_packages_ungrouped_solved =
+      solve_ungroup
+      |> Solver.keys
+      |> List.rev_map Solver.get
+      |> List.rev_map (fun pkg -> (Package.opam pkg, pkg))
+      |> OpamPackage.Map.of_list
+    in
+    let all_failures = solve_group |> Solver.failures in
+    let all_packages_jobs =
+      solve_group |> Solver.keys |> List.rev_map Solver.get
+    in
+    let all_packages =
+      all_packages_jobs |> List.rev_map Package.all_deps |> List.flatten
+    in
+    let all_opam_packages =
+      all_packages
+      |> List.rev_map (fun pkg -> Package.opam pkg)
+      |> OpamPackage.Set.of_list
+    in
+    let all_opam_packages_failures =
+      List.rev_map fst all_failures
+      |> List.flatten
+      |> List.filter (fun opam ->
+             not (OpamPackage.Set.mem opam all_opam_packages))
+    in
+    let all_packages_jobs_back =
+      all_opam_packages_failures
+      |> List.filter_map (fun opam_pkg ->
+             OpamPackage.Map.find_opt opam_pkg all_packages_ungrouped_solved)
+    in
+    let all_opam_packages_back =
+      all_packages_jobs_back
+      |> List.rev_map Package.all_deps
+      |> List.flatten
+      |> List.rev_map Package.opam
+      |> OpamPackage.Set.of_list
+    in
+    let all_opam_packages_failures =
+      List.filter
+        (fun opam_pkg ->
+          not (OpamPackage.Set.mem opam_pkg all_opam_packages_back))
+        all_opam_packages_failures
+    in
+    let all_opam_packages =
+      OpamPackage.Set.union all_opam_packages all_opam_packages_back
+    in
+    let all_packages_jobs = all_packages_jobs @ all_packages_jobs_back in
+    let schedule_jobs =
+      schedule_jobs
+        ~targets:(all_packages |> Package.Set.of_list)
+        all_packages_jobs
+    in
+    let reduced_jobs =
+      let uniq_deps = Hashtbl.create 100 in
+      List.iter
+        (fun job -> Hashtbl.replace uniq_deps (job_deps_sha job) job)
+        schedule_jobs;
+      Hashtbl.to_seq_values uniq_deps |> List.of_seq |> List.sort Jobs.compare
+    in
+    Current.Job.log job "";
+    Current.Job.log job
+      "Grouped packages by repo (take the failures that are solved individualy)";
+    summary ~job
+      ~all_packages_jobs_success:(List.length all_packages_jobs)
+      ~all_opam_packages_success:(OpamPackage.Set.cardinal all_opam_packages)
+      ~all_opam_packages_failures:
+        (OpamPackage.Set.cardinal
+        @@ OpamPackage.Set.of_list all_opam_packages_failures)
+      ~reduced_jobs:(List.length reduced_jobs)
+      ~schedule_jobs:(List.length schedule_jobs)
+      ~kind:"group-fixed";
+
+    Lwt.return @@ Ok ()
+
+  let pp = Key.pp
+  let auto_cancel = true
+end
+
+module Stats_cache = Current_cache.Make (Stats)
+
+let stats solve hash kind =
+  Current.component "stats (%s)" kind
+  |>
+  let> key = hash and> solve in
+  Stats_cache.get solve key
+
+let () = Prometheus_unix.Logging.init ()
+
+let pipeline ~repo ~limit () =
+  let opam = Git.Local.head_commit repo in
+  let tracked = Track.v ~limit ~filter:[] opam in
+  let tracked_group = Track.v ~group:true ~limit ~filter:[] opam in
+  let solver_result_c =
+    Solver.incremental ~nb_jobs:6 ~blacklist:[] ~opam tracked
+  in
+  let solver_result_c_group =
+    Current.bind
+      (fun _ ->
+        Solver.incremental ~group:true ~nb_jobs:6 ~blacklist:[] ~opam
+          tracked_group)
+      solver_result_c
+  in
+  let hash opam = Current.map (fun opam -> Git.Commit.hash opam) opam in
+  let* solve_ungroup = solver_result_c in
+  let* solve_group = solver_result_c_group in
+  let solve = Current.return { Stats.solve_group; solve_ungroup } in
+  Current.all [ stats solve (hash opam) "Summary" ]
+
+let main () mode limit repo =
+  (* Here, we set the config to request a confirmation above job with [Average] value. *)
+  let config = Current.Config.v ~confirm:Current.Level.Average () in
+  Lwt_main.run
+    (let repo = Git.Local.v (Fpath.v repo) in
+     let engine = Current.Engine.create ~config (pipeline ~repo ~limit) in
+     let site =
+       Current_web.Site.(v ~has_role:allow_all)
+         ~name:program_name
+         (Current_web.routes engine)
+     in
+     Lwt.choose [ Current.Engine.thread engine; Current_web.run ~mode site ])
+
+open Cmdliner
+
+let setup_log default_level =
+  Prometheus_unix.Logging.init ?default_level ();
+  Mirage_crypto_rng_unix.initialize (module Mirage_crypto_rng.Fortuna);
+  Logging.init ();
+  Memtrace.trace_if_requested ~context:"stats" ()
+
+let setup_log =
+  let docs = Manpage.s_common_options in
+  Term.(const setup_log $ Logs_cli.level ~docs ())
+
+let repo =
+  Arg.required
+  @@ Arg.pos 0 Arg.(some dir) None
+  @@ Arg.info ~doc:"The directory contains the .git subdirectory." ~docv:"DIR"
+       []
+
+let limit =
+  Arg.value
+  @@ Arg.opt Arg.(some int) (Some 2000)
+  @@ Arg.info ~doc:"The limit of versions of each package" [ "versions-limit" ]
+
+let version =
+  match Build_info.V1.version () with
+  | None -> "n/a"
+  | Some v -> Build_info.V1.Version.to_string v
+
+let cmd =
+  let doc = "Universes pipeline stats" in
+  let info = Cmd.info program_name ~doc ~version in
+  Cmd.v info
+    Term.(
+      term_result (const main $ setup_log $ Current_web.cmdliner $ limit $ repo))
+(* $ Docs_ci_lib.Config.cmdliner) *)
+
+let () = exit @@ Cmd.eval cmd


### PR DESCRIPTION
This PR is not intended to be merged. This is an illustration of how far can we optimize  to have less universes/jobs to deal with.

The idea can be break down in 2 stage: 

1. Group all the packages by their respective repo and version before scheduling(finding the minimal group that include all the opam packages) them. It is `The solved solved success` in the statistics.

2. There are lot of packages that doesn't change their dependencies so often between 2 different versions. So we could reduce the jobs number considering their shared dependencies. It is `Reduced jobs` in the statistics.

The statistics shows how interesting could be, to optimize ocaml-docs-ci universes. The command to start the CI to get the stats.
```
$ dune exec -- stats ../opam-repository
```

```
Total number of opam packages is 30228.

2024-03-28 17:18.14: New job: 5e59e8699a1534a5e3d22936ffcba8fc5ffee950
2024-03-28 17:18.14: opam-repository commit : 5e59e8699a1534a5e3d22936ffcba8fc5ffee950
2024-03-28 17:18.14: 
2024-03-28 17:18.14: Ungrouped packages (default)
2024-03-28 17:18.22: default> The solved jobs success    : 25340
2024-03-28 17:18.22: default> The opam packages success  : 25363
2024-03-28 17:18.22: default> The opam packages failures : 4865
2024-03-28 17:18.22: default> Scheduled jobs             : 17494
2024-03-28 17:18.22: default> Coverage                   : 25363/30228 (83.91%)
...
2024-03-28 17:18.22: 
2024-03-28 17:18.22: Grouped packages by repo
2024-03-28 17:18.26: grouped> The solved jobs success    : 13627
2024-03-28 17:18.26: grouped> The opam packages success  : 24202
2024-03-28 17:18.26: grouped> The opam packages failures : 6026
2024-03-28 17:18.26: grouped> Scheduled jobs             : 11394
2024-03-28 17:18.26: grouped> Coverage                   : 24202/30228 (80.06%)
2024-03-28 17:18.26: grouped> Reduced jobs (by deps hashes) : 6343
2024-03-28 17:18.31: 
2024-03-28 17:18.31: Grouped packages by repo (take the failures that are solved individualy)
2024-03-28 17:18.31: group-fixed> The solved jobs success    : 14797
2024-03-28 17:18.31: group-fixed> The opam packages success  : 25373
2024-03-28 17:18.31: group-fixed> The opam packages failures : 4855
2024-03-28 17:18.31: group-fixed> Scheduled jobs             : 11473
2024-03-28 17:18.31: group-fixed> Coverage                   : 25373/30228 (83.94%)
2024-03-28 17:18.31: group-fixed> Reduced jobs (by deps hashes) : 6425
2024-03-28 17:18.31: Job succeeded
```

Some indication, to understand the statistics.
- In `default`: a job/universe is package with its deps.
- In `grouped by repo`: a job/universe is a repo(git, gitlab, ...) with all the deps of packages inside the repo. 
- In `grouped by rep(fixed)` (recycling the opam packages failures that could be solved when solving them within their respective repo fails) : same as previous one, the only difference is recycling some opam packages failures as jobs.

***Improvements:***
The comparison between `group-fixed` and `default`: 
- The coverage of `group-fixed` is superior or equals to `default` by definition, we can also see this in the stats 83.94% against 83.91%, there is no loss against `default`.
- Scheduling in `group-fixed` reduce the jobs by **34.41%** ($(1 - 11473/17494)*100$) against `default`.
- Reduced jobs in `group-fixed` reduce the jobs by **63.27%** ($(1 - 6425/17494)*100$) against `default`.

This PR only implement, "Scheduled jobs" of `grouped`. Adding the "Reduced jobs" (2nd stage) is more complicated, it demands changing how the jobs are built/installed it will ends up dissociating a package with it dependencies during the build/install. In the `default` case, a package and its dependencies are built/installed once together, this is why the duplication.