### PR TITLE
Set docs to false to avoid circular reference to TyXML

### DIFF
--- a/src/solver/solver.ml
+++ b/src/solver/solver.ml
@@ -31,7 +31,7 @@ let universes ~packages (resolutions : OpamPackage.t list) =
           |> OpamFile.OPAM.depends
           |> OpamFilter.partial_filter_formula
                (OpamFilter.deps_var_env ~build:true ~post:false ~test:false
-                  ~doc:true ~dev:false)
+                  ~doc:false ~dev:false)
           |> get_names
           |> OpamPackage.Name.Set.of_list
         in


### PR DESCRIPTION
e.g.

```
2024-09-11 15:42.05: New job: incremental solver v2
2024-09-11 15:42.05: Using opam-repository sha 0329818dcfd3de1a722ea09eeeed94cd24caa375
2024-09-11 15:42.06 [INFO] Solving for ocaml-base-compiler, ocaml,
                           odoc using opam_repository_commit 0329818dcfd3de1a722ea09eeeed94cd24caa375
2024-09-11 15:42.19: Solving failed for odoc.2.4.2: Error from solver: Bad frame from worker: time="1.31" len="0.0"
2024-09-11 15:42.19: Solved: 32170 / New: 1 / Success: 0
2024-09-11 15:42.25: Job succeeded
```