### PR TITLE
Use opam 2.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
-FROM ocaml/opam:debian-12-ocaml-4.14@sha256:14f4cc396d19e5eba0c4cd8258eedd1045091f887920ba53431e1e05110311fc AS build
-RUN sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && opam init --reinit -ni
+FROM ocaml/opam:debian-12-ocaml-4.14 AS build
+RUN sudo ln -f /usr/bin/opam-2.3 /usr/bin/opam && opam init --reinit -ni
 RUN sudo apt-get update && sudo apt-get install -y capnproto graphviz libcapnp-dev libev-dev libffi-dev libgmp-dev libsqlite3-dev pkg-config
-RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 56e31a3bc1fd0bfd87e5251972e806b8f78082a5 && opam update
+RUN cd ~/opam-repository && git fetch -q origin master && git reset --hard 278df338effcd8a80241fbf6902ef949a850372c && opam update
 
 WORKDIR /src
 # See https://github.com/ocurrent/ocaml-docs-ci/pull/177#issuecomment-2445338172

--- a/dune-project
+++ b/dune-project
@@ -8,6 +8,8 @@
 (source
  (github ocurrent/ocaml-docs-ci))
 
+(license MIT)
+
 (authors "lucas@tarides.com")
 (maintainers "Navin Keswani <navin@novemberkilo.io>" "Tim McGilchrist <timmcgil@gmail.com>")
 
@@ -42,7 +44,7 @@
   (git-unix (>= 3.13.0))
   conf-libev
   dune-build-info
-  (ocaml-version (>= 3.6.9))
+  (ocaml-version (= 3.6.5))
   (obuilder-spec (>= 0.5.1))
   (ocolor (>= 1.3.0))
   (memtrace (>= 0.1.1)) ; required for memory profiling

--- a/ocaml-docs-ci-client.opam
+++ b/ocaml-docs-ci-client.opam
@@ -6,6 +6,7 @@ maintainer: [
   "Tim McGilchrist <timmcgil@gmail.com>"
 ]
 authors: ["lucas@tarides.com"]
+license: "MIT"
 homepage: "https://github.com/ocurrent/ocaml-docs-ci"
 bug-reports: "https://github.com/ocurrent/ocaml-docs-ci/issues"
 depends: [

--- a/ocaml-docs-ci.opam
+++ b/ocaml-docs-ci.opam
@@ -8,6 +8,7 @@ maintainer: [
   "Tim McGilchrist <timmcgil@gmail.com>"
 ]
 authors: ["lucas@tarides.com"]
+license: "MIT"
 homepage: "https://github.com/ocurrent/ocaml-docs-ci"
 bug-reports: "https://github.com/ocurrent/ocaml-docs-ci/issues"
 depends: [
@@ -38,7 +39,7 @@ depends: [
   "git-unix" {>= "3.13.0"}
   "conf-libev"
   "dune-build-info"
-  "ocaml-version" {>= "3.6.9"}
+  "ocaml-version" {= "3.6.5"}
   "obuilder-spec" {>= "0.5.1"}
   "ocolor" {>= "1.3.0"}
   "memtrace" {>= "0.1.1"}

--- a/src/lib/prep.ml
+++ b/src/lib/prep.ml
@@ -101,9 +101,9 @@ let spec ~ssh ~voodoo ~base ~(install : Package.t) (prep : Package.t list) =
          run "sudo mkdir /src";
          copy [ "packages" ] ~dst:"/src/packages";
          copy [ "repo" ] ~dst:"/src/repo";
-         (* Re-initialise opam after switching from opam.2.0 to 2.1. *)
+         (* Re-initialise opam after switching from opam.2.0 to 2.3. *)
          run ~network
-           "sudo ln -f /usr/bin/opam-2.1 /usr/bin/opam && opam init --reinit \
+           "sudo ln -f /usr/bin/opam-2.3 /usr/bin/opam && opam init --reinit \
             -ni";
          run "opam repo remove default && opam repo add opam /src";
          copy ~from:(`Build "tools")
@@ -121,7 +121,7 @@ let spec ~ssh ~voodoo ~base ~(install : Package.t) (prep : Package.t list) =
               [
                 "sudo apt update";
                 Fmt.str
-                  "(opam depext -viy %s 2>&1 | tee ~/opam.err.log) || echo \
+                  "(opam install -y %s 2>&1 | tee ~/opam.err.log) || echo \
                    'Failed to install all packages'"
                   packages_str;
               ];

--- a/src/lib/spec.ml
+++ b/src/lib/spec.ml
@@ -38,6 +38,8 @@ let add_rsync_retry_script =
      /usr/local/bin/rsync && ls -l /usr/bin/rsync && cat /usr/local/bin/rsync"
     rsync_retry_script
 
+let network = [ "host" ]
+
 let make base =
   let open Obuilder_spec in
   {
@@ -45,6 +47,8 @@ let make base =
     ops =
       [
         user_unix ~uid:1000 ~gid:1000;
+        run ~network
+          "sudo ln -f /usr/bin/opam-2.3 /usr/bin/opam && opam init --reinit -ni";
         workdir "/home/opam";
         run "sudo chown opam:opam /home/opam";
       ];

--- a/src/lib/voodoo.ml
+++ b/src/lib/voodoo.ml
@@ -180,7 +180,7 @@ module Prep = struct
          [
            run ~network
              "sudo apt-get update && sudo apt-get install -yy m4 pkg-config";
-           run ~network ~cache "opam pin -ny %s  && opam depext -iy voodoo-prep"
+           run ~network ~cache "opam pin -ny %s  && opam install -y voodoo-prep"
              (remote_uri t);
            run "cp $(opam config var bin)/voodoo-prep /home/opam";
          ]
@@ -203,7 +203,7 @@ module Do = struct
     |> Spec.add
          [
            run ~network "sudo apt-get update && sudo apt-get install -yy m4";
-           run ~network ~cache "opam pin -ny %s && opam depext -iy voodoo-do"
+           run ~network ~cache "opam pin -ny %s && opam install -y voodoo-do"
              (remote_uri t.commit);
            run
              "cp $(opam config var bin)/odoc $(opam config var bin)/voodoo-do \
@@ -226,7 +226,7 @@ module Gen = struct
     |> Spec.add
          [
            run ~network "sudo apt-get update && sudo apt-get install -yy m4";
-           run ~network ~cache "opam pin -ny %s  && opam depext -iy voodoo-gen"
+           run ~network ~cache "opam pin -ny %s  && opam install -y voodoo-gen"
              (remote_uri t.commit);
            run
              "cp $(opam config var bin)/odoc $(opam config var bin)/voodoo-gen \

--- a/src/solver/git_context.ml
+++ b/src/solver/git_context.ml
@@ -28,7 +28,7 @@ let filter_deps t pkg f =
   let test = OpamPackage.Name.Set.mem (OpamPackage.name pkg) t.test in
   f
   |> OpamFilter.partial_filter_formula (env t pkg)
-  |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev
+  |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev ~dev_setup:false
        ~default:false
 
 let candidates t name =

--- a/src/solver/git_context.ml
+++ b/src/solver/git_context.ml
@@ -28,8 +28,8 @@ let filter_deps t pkg f =
   let test = OpamPackage.Name.Set.mem (OpamPackage.name pkg) t.test in
   f
   |> OpamFilter.partial_filter_formula (env t pkg)
-  |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev ~dev_setup:false
-       ~default:false
+  |> OpamFilter.filter_deps ~build:true ~post:true ~test ~doc:false ~dev
+       ~dev_setup:false ~default:false
 
 let candidates t name =
   match OpamPackage.Name.Map.find_opt name t.pins with

--- a/src/solver/solver.ml
+++ b/src/solver/solver.ml
@@ -31,7 +31,7 @@ let universes ~packages (resolutions : OpamPackage.t list) =
           |> OpamFile.OPAM.depends
           |> OpamFilter.partial_filter_formula
                (OpamFilter.deps_var_env ~build:true ~post:false ~test:false
-                  ~doc:false ~dev:false)
+                  ~doc:false ~dev_setup:false ~dev:false)
           |> get_names
           |> OpamPackage.Name.Set.of_list
         in
@@ -40,7 +40,7 @@ let universes ~packages (resolutions : OpamPackage.t list) =
           |> OpamFile.OPAM.depopts
           |> OpamFilter.partial_filter_formula
                (OpamFilter.deps_var_env ~build:true ~post:false ~test:false
-                  ~doc:true ~dev:false)
+                  ~doc:false ~dev_setup:false ~dev:false)
           |> get_names
           |> OpamPackage.Name.Set.of_list
         in


### PR DESCRIPTION
docs-ci jobs are failing to build `voodoo` as `odoc.3.0.0~beta1` is selected by opam.  This is because opam 2.0 is being used which does not take account of the `avoid-version` flag set on `3.0.0~beta1`.

This PR updates opam to 2.3 in job spec `src/lib/spec.ml`:
```
+        run ~network
+          "sudo ln -f /usr/bin/opam-2.3 /usr/bin/opam && opam init --reinit -ni";
```

The opam command line for `opam depext` changed after opam 2.0 hence `opam depext -iy` becomes `opam install -y`.

Thanks to @jonludlam and @dra27.